### PR TITLE
Add CI release manifest step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,4 +35,4 @@ jobs:
       - name: Push release manifest
         uses: softprops/action-gh-release@v1
         with:
-          files: deploy/flink-operator.yaml
+          files: config/deploy/flink-operator.yaml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,10 +25,14 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: "^1.17"
-      - run: make docker-push
+      - run: make release-manifest docker-push
         env:
           IMG: ${{ steps.prep.outputs.image }}
       - name: Tag latest
         run: docker tag ${{ steps.prep.outputs.image }} ${DOCKER_REPO}:latest
       - name: Push latest
         run: docker push ${DOCKER_REPO}:latest
+      - name: Push release manifest
+        uses: softprops/action-gh-release@v1
+        with:
+          files: deploy/flink-operator.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-VERSION := latest
+VERSION ?= latest
 # Image URL to use all building/pushing image targets
 IMG ?= ghcr.io/spotify/flink-operator:$(VERSION)
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)


### PR DESCRIPTION
Closes #102 

This allows us to have per release a default manifest that users can install through:

```
kubectl apply -f https://github.com/spotify/flink-on-k8s-operator/releases/download/$VERSION/flink-operator.yaml
```

instead of requiring `make deploy`