### PR TITLE
V2 Implementation

### DIFF
--- a/api/v1beta1/flinkcluster_types.go
+++ b/api/v1beta1/flinkcluster_types.go
@@ -719,12 +719,12 @@ type FlinkClusterStatus struct {
 	LastUpdateTime string `json:"lastUpdateTime,omitempty"`
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
-// +kubebuilder:resource:shortName="fc"
-// +kubebuilder:printcolumn:name="version",type=string,JSONPath=`.spec.flinkVersion`
-// +kubebuilder:printcolumn:name="status",type=string,JSONPath=`.status.state`
-// +kubebuilder:printcolumn:name="age",type=date,JSONPath=`.metadata.creationTimestamp`
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
+//+kubebuilder:resource:shortName="fc"
+//+kubebuilder:printcolumn:name="version",type=string,JSONPath=`.spec.flinkVersion`
+//+kubebuilder:printcolumn:name="status",type=string,JSONPath=`.status.state`
+//+kubebuilder:printcolumn:name="age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // FlinkCluster is the Schema for the flinkclusters API
 type FlinkCluster struct {
@@ -735,8 +735,8 @@ type FlinkCluster struct {
 	Status FlinkClusterStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName="fc"
+//+kubebuilder:object:root=true
+//+kubebuilder:resource:shortName="fc"
 
 // FlinkClusterList contains a list of FlinkCluster
 type FlinkClusterList struct {

--- a/api/v1beta1/flinkcluster_webhook.go
+++ b/api/v1beta1/flinkcluster_webhook.go
@@ -54,9 +54,9 @@ var _ webhook.Defaulter = &FlinkCluster{}
 // Default implements webhook.Defaulter so a webhook will be registered for the
 // type.
 func (cluster *FlinkCluster) Default() {
-	log.Info("default", "name", cluster.Name, "original", *cluster)
+	// log.Info("default", "name", cluster.Name, "original", *cluster)
 	_SetDefault(cluster)
-	log.Info("default", "name", cluster.Name, "augmented", *cluster)
+	// log.Info("default", "name", cluster.Name, "augmented", *cluster)
 }
 
 /*

--- a/controllers/flink/client.go
+++ b/controllers/flink/client.go
@@ -95,6 +95,26 @@ type Job struct {
 	Duration  int64  `json:"duration"`
 }
 
+type JobSorter struct {
+	Jobs []Job
+	By   func(p1, p2 *Job) bool // Closure used in the Less method.
+}
+
+// Len is part of sort.Interface.
+func (s *JobSorter) Len() int {
+	return len(s.Jobs)
+}
+
+// Swap is part of sort.Interface.
+func (s *JobSorter) Swap(i, j int) {
+	s.Jobs[i], s.Jobs[j] = s.Jobs[j], s.Jobs[i]
+}
+
+// Less is part of sort.Interface. It is implemented by calling the "by" closure in the sorter.
+func (s *JobSorter) Less(i, j int) bool {
+	return s.By(&s.Jobs[i], &s.Jobs[j])
+}
+
 // JobsOverview defines Flink job overview list.
 type JobsOverview struct {
 	Jobs []Job

--- a/controllers/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster_reconciler.go
@@ -177,7 +177,8 @@ func (reconciler *ClusterReconciler) createStatefulSet(
 	var log = reconciler.log.WithValues("component", component)
 	var k8sClient = reconciler.k8sClient
 
-	log.Info("Creating StatefulSet", "StatefulSet", *statefulSet)
+	log.Info("Creating StatefulSet")
+
 	var err = k8sClient.Create(context, statefulSet)
 	if err != nil {
 		log.Error(err, "Failed to create StatefulSet")
@@ -279,7 +280,8 @@ func (reconciler *ClusterReconciler) createService(
 	var log = reconciler.log.WithValues("component", component)
 	var k8sClient = reconciler.k8sClient
 
-	log.Info("Creating service", "resource", *service)
+	log.Info("Creating service")
+
 	var err = k8sClient.Create(context, service)
 	if err != nil {
 		log.Info("Failed to create service", "error", err)
@@ -344,7 +346,8 @@ func (reconciler *ClusterReconciler) createIngress(
 	var log = reconciler.log.WithValues("component", component)
 	var k8sClient = reconciler.k8sClient
 
-	log.Info("Creating ingress", "resource", *ingress)
+	log.Info("Creating ingress")
+
 	var err = k8sClient.Create(context, ingress)
 	if err != nil {
 		log.Info("Failed to create ingress", "error", err)
@@ -409,7 +412,8 @@ func (reconciler *ClusterReconciler) createConfigMap(
 	var log = reconciler.log.WithValues("component", component)
 	var k8sClient = reconciler.k8sClient
 
-	log.Info("Creating configMap", "configMap", *cm)
+	log.Info("Creating configMap")
+
 	var err = k8sClient.Create(context, cm)
 	if err != nil {
 		log.Info("Failed to create configMap", "error", err)
@@ -604,7 +608,7 @@ func (reconciler *ClusterReconciler) createJob(job *batchv1.Job) error {
 	var log = reconciler.log
 	var k8sClient = reconciler.k8sClient
 
-	log.Info("Submitting job", "resource", *job)
+	log.Info("Submitting job")
 	var err = k8sClient.Create(context, job)
 	if err != nil {
 		log.Info("Failed to created job", "error", err)
@@ -990,7 +994,9 @@ func (reconciler *ClusterReconciler) updateStatus(ss **v1beta1.SavepointStatus, 
 			newStatus.Control = controlStatus
 		}
 		setTimestamp(&newStatus.LastUpdateTime)
-		log.Info("Updating cluster status", "clusterClone", clusterClone, "newStatus", newStatus)
+
+		log.Info("Updating cluster status")
+
 		statusUpdateErr = reconciler.k8sClient.Status().Update(reconciler.context, clusterClone)
 		if statusUpdateErr == nil {
 			return nil
@@ -1040,8 +1046,7 @@ func (reconciler *ClusterReconciler) updateStatusForNewJob() error {
 	err = reconciler.k8sClient.Status().Update(reconciler.context, clusterClone)
 
 	if err != nil {
-		log.Error(
-			err, "Failed to update job status for new job submission", "error", err)
+		log.Error(err, "Failed to update job status for new job submission", "error", err)
 	} else {
 		log.Info("Succeeded to update job status for new job submission.", "job status", newJobStatus)
 	}

--- a/controllers/flinkcluster_v2_converter.go
+++ b/controllers/flinkcluster_v2_converter.go
@@ -1,0 +1,117 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"time"
+
+	v1beta1 "github.com/spotify/flink-on-k8s-operator/api/v1beta1"
+	"github.com/spotify/flink-on-k8s-operator/controllers/model"
+)
+
+// Converter which converts the FlinkCluster spec to the desired
+// underlying Kubernetes resource specs.
+
+// Gets the desired state of a cluster.
+func (handler *FlinkClusterHandlerV2) getDesiredClusterState(observed ObservedClusterState, now time.Time) model.DesiredClusterState {
+	var cluster = observed.cluster
+
+	// The cluster has been deleted, all resources should be cleaned up.
+	if observed.cluster == nil {
+		return model.DesiredClusterState{}
+	}
+
+	return model.DesiredClusterState{
+		ConfigMap:     getDesiredConfigMap(cluster, !handler.shouldCreateResource(observed, "ConfigMap")),
+		JmStatefulSet: getDesiredJobManagerStatefulSet(observed.cluster, !handler.shouldCreateResource(observed, "JobManagerStatefulSet")),
+		JmService:     getDesiredJobManagerService(observed.cluster, !handler.shouldCreateResource(observed, "JobManagerService")),
+		JmIngress:     getDesiredJobManagerIngress(observed.cluster, !handler.shouldCreateResource(observed, "JobManagerIngress")),
+		TmStatefulSet: getDesiredTaskManagerStatefulSet(observed.cluster, !handler.shouldCreateResource(observed, "TaskManagerStatefulSet")),
+		Job:           getDesiredJob(observed.cluster, !handler.shouldCreateJob(observed)),
+	}
+}
+
+// ======================================================================================
+
+func (handler *FlinkClusterHandlerV2) shouldCreateJob(observed ObservedClusterState) bool {
+	if observed.cluster.Spec.Job == nil {
+		handler.log.Info("Is not job cluster")
+		return false
+	}
+
+	if isJobCancelRequested(*observed.cluster) {
+		return false
+	}
+
+	if observed.isNewRevision() {
+		return true
+	}
+
+	if observed.cluster.Status.Components.Job != nil {
+		switch observed.cluster.Status.Components.Job.State {
+		case v1beta1.JobStateFailed, v1beta1.JobStateCancelled, v1beta1.JobStateSuspended, v1beta1.JobStateLost:
+			if shouldRestartJobV2(observed.cluster.Spec.Job.RestartPolicy, observed.cluster.Status.Components.Job) {
+				return true
+			} else {
+				return false
+			}
+		case v1beta1.JobStateSucceeded:
+			handler.log.Info("Status succeeded")
+			return false
+		default:
+			handler.log.Info("Other status")
+		}
+	}
+
+	return true
+}
+
+func (handler *FlinkClusterHandlerV2) shouldCreateResource(observed ObservedClusterState, component string) bool {
+
+	// Session cluster.
+	if observed.cluster.Spec.Job == nil {
+		return true
+	}
+
+	// Job not started
+	if observed.cluster.Status.Components.Job == nil {
+		return true
+	}
+
+	if observed.isNewRevision() {
+		return true
+	}
+
+	var action v1beta1.CleanupAction
+	switch observed.cluster.Status.Components.Job.State {
+	case v1beta1.JobStateSucceeded:
+		action = observed.cluster.Spec.Job.CleanupPolicy.AfterJobSucceeds
+	case v1beta1.JobStateFailed, v1beta1.JobStateLost:
+		action = observed.cluster.Spec.Job.CleanupPolicy.AfterJobFails
+	case v1beta1.JobStateCancelled:
+		action = observed.cluster.Spec.Job.CleanupPolicy.AfterJobCancelled
+	default:
+		return true
+	}
+
+	switch action {
+	case v1beta1.CleanupActionDeleteCluster:
+		return false
+	case v1beta1.CleanupActionDeleteTaskManager:
+		return component != "TaskManagerStatefulSet"
+	default:
+		return true
+	}
+}

--- a/controllers/flinkcluster_v2_handler.go
+++ b/controllers/flinkcluster_v2_handler.go
@@ -1,0 +1,128 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"time"
+
+	"github.com/spotify/flink-on-k8s-operator/controllers/flink"
+	"github.com/spotify/flink-on-k8s-operator/controllers/history"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type FlinkClusterHandlerV2 struct {
+	k8sClient    client.Client
+	k8sClientset *kubernetes.Clientset
+	flinkClient  *flink.Client
+	request      ctrl.Request
+	log          logr.Logger
+	recorder     record.EventRecorder
+}
+
+func (handler *FlinkClusterHandlerV2) reconcile(ctx context.Context) (ctrl.Result, error) {
+	var log = handler.log
+
+	var controllerHistory = history.NewHistory(handler.k8sClient, ctx)
+
+	handler.logStart()
+	log.Info("---------- 1. Observe the current state ----------")
+
+	observed, observedErr := handler.observe(ctx, controllerHistory)
+	if observedErr != nil {
+		log.Error(observedErr, "Failed to observe the current state")
+		handler.logEnd()
+		return ctrl.Result{}, observedErr
+	}
+
+	// Sync history and observe revision status
+	syncErr := handler.syncRevisionStatus(&observed, controllerHistory)
+	if syncErr != nil {
+		log.Error(syncErr, "Failed to sync flinkCluster history")
+		handler.logEnd()
+		return ctrl.Result{}, syncErr
+	}
+
+	log.Info("---------- 2. Update cluster status ----------")
+
+	statusChanged, statusChangedErr := handler.updateStatusIfChanged(ctx, observed)
+	if statusChangedErr != nil {
+		log.Error(statusChangedErr, "Failed to update cluster status")
+		handler.logEnd()
+		return ctrl.Result{}, statusChangedErr
+	}
+
+	if statusChanged {
+		log.Info("Wait status to be stable before taking further actions.")
+		handler.logRequeue()
+		return ctrl.Result{RequeueAfter: 5 * time.Second, Requeue: true}, nil
+	}
+
+	log.Info("---------- 3. Compute the desired state ----------")
+
+	desired := handler.getDesiredClusterState(observed, time.Now())
+
+	// desiredClusterState := StateFromDesired(*desired)
+	// observedClusterState := StateFromObserved(*observed)
+
+	// if diff := cmp.Diff(desiredClusterState, observedClusterState); diff != "" {
+	// 	handler.log.Info("State diff", "diff", diff)
+	// }
+
+	log.Info("---------- 4. Take actions ----------")
+
+	var reconciler = ClusterReconciler{
+		context:     ctx,
+		desired:     desired,
+		flinkClient: handler.flinkClient,
+		k8sClient:   handler.k8sClient,
+		log:         log,
+		observed:    observed,
+		recorder:    handler.recorder,
+	}
+
+	result, err := reconciler.reconcile()
+
+	if err != nil {
+		log.Error(err, "Failed to reconcile")
+	} else {
+		log.Info("Reconcile completed")
+	}
+	if result.RequeueAfter > 0 {
+		handler.logRequeue()
+	} else {
+		handler.logEnd()
+	}
+
+	return result, err
+}
+
+func (handler *FlinkClusterHandlerV2) logStart() {
+	handler.log.Info("======================== START ========================")
+}
+
+func (handler *FlinkClusterHandlerV2) logEnd() {
+	handler.log.Info("========================  END  ========================")
+}
+
+func (handler *FlinkClusterHandlerV2) logRequeue() {
+	handler.log.Info("========================  REQ  ========================")
+}

--- a/controllers/flinkcluster_v2_observer.go
+++ b/controllers/flinkcluster_v2_observer.go
@@ -1,0 +1,707 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	v1beta1 "github.com/spotify/flink-on-k8s-operator/api/v1beta1"
+	"github.com/spotify/flink-on-k8s-operator/controllers/flink"
+	"github.com/spotify/flink-on-k8s-operator/controllers/history"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Observes the state of the cluster and its components.
+// NOT_FOUND error is ignored because it is normal, other errors are returned.
+func (observer *FlinkClusterHandlerV2) observe(ctx context.Context, controllerHistory history.Interface) (ObservedClusterState, error) {
+	var observed = ObservedClusterState{}
+
+	var err error
+	var log = observer.log
+
+	// Cluster.
+	observed.cluster, err = observer.observeCluster(ctx)
+	if err != nil && client.IgnoreNotFound(err) != nil {
+		log.Error(err, "Failed to get the cluster resource")
+		return observed, err
+	}
+
+	// Revisions.
+	observed.revisions, err = observer.observeRevisions(observed.cluster, controllerHistory)
+	if err != nil && client.IgnoreNotFound(err) != nil {
+		log.Error(err, "Failed to get the controllerRevision resource list")
+		return observed, err
+	}
+
+	// ConfigMap.
+	observed.configMap, err = observer.observeConfigMap(ctx)
+	if err != nil && client.IgnoreNotFound(err) != nil {
+		log.Error(err, "Failed to get configMap")
+		return observed, err
+	}
+
+	// JobManager StatefulSet.
+	observed.jmStatefulSet, err = observer.observeStatefulSet(ctx, getJobManagerStatefulSetName(observer.request.Name))
+	if err != nil && client.IgnoreNotFound(err) != nil {
+		log.Error(err, "Failed to get JobManager StatefulSet")
+		return observed, err
+	}
+
+	// JobManager Service.
+	observed.jmService, err = observer.observeJobManagerService(ctx)
+	if err != nil && client.IgnoreNotFound(err) != nil {
+		log.Error(err, "Failed to get JobManager service")
+		return observed, err
+	}
+
+	// (Optional) JobManager Ingress.
+	observed.jmIngress, err = observer.observeJobManagerIngress(ctx)
+	if err != nil && client.IgnoreNotFound(err) != nil {
+		log.Error(err, "Failed to get JobManager ingress")
+		return observed, err
+	}
+
+	// TaskManager StatefulSet.
+	observed.tmStatefulSet, err = observer.observeStatefulSet(ctx, getTaskManagerStatefulSetName(observer.request.Name))
+	if err != nil && client.IgnoreNotFound(err) != nil {
+		log.Error(err, "Failed to get TaskManager StatefulSet")
+		return observed, err
+	}
+
+	// PersistentVolumeClaims.
+	observed.persistentVolumeClaims, _ = observer.observePersistentVolumeClaims(ctx)
+	if err != nil && client.IgnoreNotFound(err) != nil {
+		log.Error(err, "Failed to get PersistentVolumeClaims")
+	}
+
+	// Job.
+	observed.job, err = observer.observeJobSubmitterJob(ctx, observed)
+	if err != nil && client.IgnoreNotFound(err) != nil {
+		log.Error(err, "Failed to get JobSubmitter Job")
+		return observed, err
+	}
+
+	observed.jobPod, _ = observer.observeJobSubmitterPod(ctx, observed)
+	observed.flinkJobSubmitLog, _ = observer.observeFlinkJobSubmitLog(observed)
+
+	observed.flinkJobStatus = observer.observeFlinkJobStatus(observed)
+
+	// Savepoint.
+	observed.savepoint, observed.savepointErr = observer.observeSavepoint(observed)
+
+	observed.observeTime = time.Now()
+
+	return observed, nil
+}
+
+func (observer *FlinkClusterHandlerV2) observeCluster(ctx context.Context) (*v1beta1.FlinkCluster, error) {
+	observedCluster := new(v1beta1.FlinkCluster)
+	err := observer.k8sClient.Get(ctx, observer.request.NamespacedName, observedCluster)
+	if err != nil {
+		return nil, err
+	} else {
+		return observedCluster, nil
+	}
+}
+
+func (observer *FlinkClusterHandlerV2) observeRevisions(cluster *v1beta1.FlinkCluster, controllerHistory history.Interface) ([]*appsv1.ControllerRevision, error) {
+	if cluster == nil {
+		return nil, nil
+	}
+
+	var observedRevisions []*appsv1.ControllerRevision
+
+	selector := labels.SelectorFromSet(labels.Set(map[string]string{history.ControllerRevisionManagedByLabel: cluster.GetName()}))
+	controllerRevisions, err := controllerHistory.ListControllerRevisions(cluster, selector)
+	observedRevisions = append(observedRevisions, controllerRevisions...)
+
+	if err != nil {
+		return nil, err
+	} else {
+		var b strings.Builder
+		for _, cr := range observedRevisions {
+			fmt.Fprintf(&b, "{name: %v, revision: %v},", cr.Name, cr.Revision)
+		}
+		return observedRevisions, nil
+	}
+}
+
+func (observer *FlinkClusterHandlerV2) observeConfigMap(ctx context.Context) (*corev1.ConfigMap, error) {
+	observedConfigMap := new(corev1.ConfigMap)
+	err := observer.k8sClient.Get(
+		ctx,
+		types.NamespacedName{
+			Namespace: observer.request.Namespace,
+			Name:      getConfigMapName(observer.request.Name),
+		},
+		observedConfigMap)
+
+	if err != nil {
+		return nil, err
+	} else {
+		return observedConfigMap, nil
+	}
+}
+
+func (observer *FlinkClusterHandlerV2) observeStatefulSet(ctx context.Context, statefulSetName string) (*appsv1.StatefulSet, error) {
+	observedStatefulSet := new(appsv1.StatefulSet)
+	err := observer.k8sClient.Get(
+		ctx,
+		types.NamespacedName{
+			Namespace: observer.request.Namespace,
+			Name:      statefulSetName,
+		},
+		observedStatefulSet)
+
+	if err != nil {
+		return nil, err
+	} else {
+		return observedStatefulSet, nil
+	}
+}
+
+func (observer *FlinkClusterHandlerV2) observeJobManagerService(ctx context.Context) (*corev1.Service, error) {
+	observedJmService := new(corev1.Service)
+	err := observer.k8sClient.Get(
+		ctx,
+		types.NamespacedName{
+			Namespace: observer.request.Namespace,
+			Name:      getJobManagerServiceName(observer.request.Name),
+		},
+		observedJmService)
+
+	if err != nil {
+		return nil, err
+	} else {
+		return observedJmService, nil
+	}
+}
+
+func (observer *FlinkClusterHandlerV2) observeJobManagerIngress(ctx context.Context) (*extensionsv1beta1.Ingress, error) {
+	observedJmIngress := new(extensionsv1beta1.Ingress)
+
+	err := observer.k8sClient.Get(
+		ctx,
+		types.NamespacedName{
+			Namespace: observer.request.Namespace,
+			Name:      getJobManagerIngressName(observer.request.Name),
+		},
+		observedJmIngress)
+
+	if err != nil {
+		return nil, err
+	} else {
+		return observedJmIngress, nil
+	}
+}
+
+func (observer *FlinkClusterHandlerV2) observePersistentVolumeClaims(ctx context.Context) (*corev1.PersistentVolumeClaimList, error) {
+	observedClaims := new(corev1.PersistentVolumeClaimList)
+	selector := labels.SelectorFromSet(map[string]string{"cluster": observer.request.Name})
+	err := observer.k8sClient.List(
+		ctx,
+		observedClaims,
+		client.InNamespace(observer.request.Namespace),
+		client.MatchingLabelsSelector{Selector: selector})
+
+	if err != nil {
+		return nil, err
+	} else {
+		return observedClaims, nil
+	}
+}
+
+func (observer *FlinkClusterHandlerV2) observeJobSubmitterJob(ctx context.Context, observed ObservedClusterState) (*batchv1.Job, error) {
+	// Either the cluster has been deleted or it is a session cluster.
+	if observed.cluster == nil || observed.cluster.Spec.Job == nil {
+		return nil, nil
+	}
+
+	// Job resource.
+	observedJob := new(batchv1.Job)
+
+	var clusterNamespace = observer.request.Namespace
+	var clusterName = observer.request.Name
+
+	err := observer.k8sClient.Get(
+		ctx,
+		types.NamespacedName{
+			Namespace: clusterNamespace,
+			Name:      getJobName(clusterName),
+		},
+		observedJob)
+
+	if err != nil {
+		return nil, err
+	} else {
+		return observedJob, nil
+	}
+}
+
+func (observer *FlinkClusterHandlerV2) observeJobSubmitterPod(ctx context.Context, observed ObservedClusterState) (*corev1.Pod, error) {
+	// Either the cluster has been deleted or it is a session cluster.
+	if observed.cluster == nil || observed.cluster.Spec.Job == nil {
+		return nil, nil
+	}
+
+	observedPod := new(corev1.Pod)
+
+	var clusterNamespace = observer.request.Namespace
+	var clusterName = observer.request.Name
+	var podSelector = labels.SelectorFromSet(map[string]string{"job-name": getJobName(clusterName)})
+	var podList = new(corev1.PodList)
+
+	var err = observer.k8sClient.List(
+		ctx,
+		podList,
+		client.InNamespace(clusterNamespace),
+		client.MatchingLabelsSelector{Selector: podSelector})
+	if err != nil {
+		return nil, err
+	}
+
+	if podList != nil && len(podList.Items) > 0 {
+		podList.Items[0].DeepCopyInto(observedPod)
+	} else {
+		return nil, nil
+	}
+
+	return observedPod, nil
+}
+
+func (observer *FlinkClusterHandlerV2) observeFlinkJobSubmitLog(observed ObservedClusterState) (*FlinkJobSubmitLog, error) {
+	// Either the cluster has been deleted or it is a session cluster.
+	if observed.cluster == nil || observed.jobPod == nil || observed.cluster.Spec.Job == nil {
+		return nil, nil
+	}
+
+	// Extract submit result.
+	observedFlinkJobSubmitLog, err := getFlinkJobSubmitLog(observer.k8sClientset, observed.jobPod)
+	if err != nil {
+		observer.log.Info("Failed to extract job submit result", "error", err.Error())
+	}
+
+	return observedFlinkJobSubmitLog, err
+}
+
+// Observes Flink job status through Flink API (instead of Kubernetes jobs through
+// Kubernetes API).
+//
+// This needs to be done after the job manager is ready, because we use it to detect whether the Flink API server is up
+// and running.
+func (observer *FlinkClusterHandlerV2) observeFlinkJobStatus(observed ObservedClusterState) FlinkJobStatus {
+	// Either the cluster has been deleted or it is a session cluster.
+	if observed.cluster == nil || observed.cluster.Spec.Job == nil {
+		return FlinkJobStatus{}
+	}
+
+	var log = observer.log
+	flinkJobStatus := FlinkJobStatus{}
+
+	// Wait until the job manager is ready.
+	jmReady := observed.jmStatefulSet != nil && getStatefulSetState(observed.jmStatefulSet) == v1beta1.ComponentStateReady
+	if !jmReady {
+		log.Info("Skip getting Flink job status; JobManager is not ready")
+		return flinkJobStatus
+	}
+
+	// Check expected job id from submission log
+	var expectedJobId *string
+	if observed.flinkJobSubmitLog != nil {
+		expectedJobId = &observed.flinkJobSubmitLog.JobID
+	} else {
+		expectedJobId = nil
+	}
+
+	// Observe job from cluster
+	flinkAPIBaseURL := getFlinkAPIBaseURL(observed.cluster)
+	flinkJobList, err := observer.flinkClient.GetJobsOverview(flinkAPIBaseURL)
+	if err != nil {
+		// It is normal in many cases, not an error.
+		log.Info("Failed to get Flink job status list.", "error", err)
+		return flinkJobStatus
+	}
+	flinkJobStatus.flinkJobList = flinkJobList
+
+	var runningFlinkJobIds []flink.Job
+	var stoppedFlinkJobIds []flink.Job
+
+	for _, job := range flinkJobList.Jobs {
+		switch job.State {
+		case "INITIALIZING", "CREATED", "RUNNING", "FAILING", "CANCELLING", "RESTARTING", "RECONCILING":
+			runningFlinkJobIds = append(runningFlinkJobIds, job)
+		case "FINISHED", "CANCELED", "FAILED", "SUSPENDED":
+			stoppedFlinkJobIds = append(stoppedFlinkJobIds, job)
+		default:
+			log.Info("Unknown status", "status", job.State)
+		}
+	}
+
+	startTimeComparator := func(p1, p2 *flink.Job) bool {
+		return p1.StartTime > p2.StartTime
+	}
+	sort.Sort(&flink.JobSorter{
+		Jobs: runningFlinkJobIds,
+		By:   startTimeComparator,
+	})
+	sort.Sort(&flink.JobSorter{
+		Jobs: stoppedFlinkJobIds,
+		By:   startTimeComparator,
+	})
+
+	if len(runningFlinkJobIds) > 0 {
+		flinkJobStatus.flinkJob = &runningFlinkJobIds[0]
+	} else if len(stoppedFlinkJobIds) > 0 {
+		flinkJobStatus.flinkJob = &stoppedFlinkJobIds[0]
+	}
+
+	if len(runningFlinkJobIds) > 1 {
+		// Unexpected jobs
+		flinkJobStatus.flinkJobsUnexpected = make([]string, 0)
+		for _, job := range flinkJobList.Jobs {
+			if flinkJobStatus.flinkJob.Id != job.Id {
+				flinkJobStatus.flinkJobsUnexpected = append(flinkJobStatus.flinkJobsUnexpected, job.Id)
+			}
+		}
+	}
+
+	if expectedJobId == nil {
+		if len(runningFlinkJobIds) > 0 {
+			log.Info(fmt.Sprintf("No expected job. Job id %s is found.", flinkJobStatus.flinkJob.Id))
+		} else {
+			log.Info("No expected job, no job running.")
+		}
+	} else {
+		if flinkJobStatus.flinkJob != nil {
+			if *expectedJobId != flinkJobStatus.flinkJob.Id {
+				log.Info(fmt.Sprintf("Job ID mismatch. Expected job id %s but job id %s is found", *expectedJobId, flinkJobStatus.flinkJob.Id))
+				flinkJobStatus.flinkJobExceptions = observer.observeFlinkJobException(observed, flinkAPIBaseURL, *expectedJobId)
+			} else {
+				log.Info("Job id match.")
+			}
+		} else {
+			log.Info(fmt.Sprintf("Job ID missing. Expected job id %s but no job is found", *expectedJobId))
+		}
+	}
+
+	// Unexpected jobs
+	if len(flinkJobStatus.flinkJobsUnexpected) > 1 {
+		log.Error(errors.New("more than one unexpected Flink job were found"), "", "unexpected jobs", flinkJobStatus.flinkJobsUnexpected)
+	}
+
+	if flinkJobStatus.flinkJob != nil {
+		log.Info("Observed Flink job", "flink job", *flinkJobStatus.flinkJob)
+	}
+
+	return flinkJobStatus
+}
+
+func (observer *FlinkClusterHandlerV2) observeFlinkJobException(observed ObservedClusterState, flinkAPIBaseURL string, flinkJobID string) *flink.JobExceptions {
+	var log = observer.log
+	flinkJobExceptions, err := observer.flinkClient.GetJobExceptions(flinkAPIBaseURL, flinkJobID)
+	if err != nil {
+		// It is normal in many cases, not an error.
+		log.Info("Failed to get Flink job exceptions.", "error", err)
+		return nil
+	}
+	log.Info("Observed Flink job exceptions", "jobs", flinkJobExceptions)
+	return flinkJobExceptions
+}
+
+func (observer *FlinkClusterHandlerV2) observeSavepoint(observed ObservedClusterState) (*flink.SavepointStatus, error) {
+	var log = observer.log
+
+	if observed.cluster == nil {
+		return nil, nil
+	}
+
+	// Get savepoint status in progress.
+	var savepointStatus = observed.cluster.Status.Savepoint
+
+	if savepointStatus != nil && savepointStatus.State == v1beta1.SavepointStateInProgress {
+		var flinkAPIBaseURL = getFlinkAPIBaseURL(observed.cluster)
+		var jobID = savepointStatus.JobID
+		var triggerID = savepointStatus.TriggerID
+
+		savepoint, err := observer.flinkClient.GetSavepointStatus(flinkAPIBaseURL, jobID, triggerID)
+
+		if err == nil && len(savepoint.FailureCause.StackTrace) > 0 {
+			err = fmt.Errorf("%s", savepoint.FailureCause.StackTrace)
+		}
+		if err != nil {
+			log.Info("Failed to get savepoint.", "error", err, "jobID", jobID, "triggerID", triggerID)
+		}
+
+		return savepoint, err
+	}
+
+	return nil, nil
+}
+
+// syncRevisionStatus synchronizes current FlinkCluster resource and its child ControllerRevision resources.
+// When FlinkCluster resource is edited, the operator creates new child ControllerRevision for it
+// and updates nextRevision in FlinkClusterStatus to the name of the new ControllerRevision.
+// At that time, the name of the ControllerRevision is composed with the hash string generated
+// from the FlinkClusterSpec which is to be stored in it.
+// Therefore the contents of the ControllerRevision resources are maintained not duplicate.
+// If edited FlinkClusterSpec is the same with the content of any existing ControllerRevision resources,
+// the operator will only update nextRevision of the FlinkClusterStatus to the name of the ControllerRevision
+// that has the same content, instead of creating new ControllerRevision.
+// Finally, it maintains the number of child ControllerRevision resources according to RevisionHistoryLimit.
+func (observer *FlinkClusterHandlerV2) syncRevisionStatus(observed *ObservedClusterState, controllerHistory history.Interface) error {
+	if observed.cluster == nil {
+		return nil
+	}
+
+	var revisions = observed.revisions
+	var cluster = observed.cluster
+	var recordedStatus = cluster.Status
+	var currentRevision, nextRevision *appsv1.ControllerRevision
+	var revisionStatus = observed.revisionStatus
+
+	revisionCount := len(revisions)
+	history.SortControllerRevisions(revisions)
+
+	// Use a local copy of cluster.Status.CollisionCount to avoid modifying cluster.Status directly.
+	var collisionCount int32
+	if recordedStatus.CollisionCount != nil {
+		collisionCount = *recordedStatus.CollisionCount
+	}
+
+	// create a new revision from the current cluster
+	nextRevision, err := newRevision(cluster, getNextRevisionNumber(revisions), &collisionCount)
+	if err != nil {
+		return err
+	}
+
+	// find any equivalent revisions
+	equalRevisions := history.FindEqualRevisions(revisions, nextRevision)
+	equalCount := len(equalRevisions)
+	if equalCount > 0 && history.EqualRevision(revisions[revisionCount-1], equalRevisions[equalCount-1]) {
+		// if the equivalent revision is immediately prior the next revision has not changed
+		nextRevision = revisions[revisionCount-1]
+	} else if equalCount > 0 {
+		// if the equivalent revision is not immediately prior we will roll back by incrementing the
+		// Revision of the equivalent revision
+		nextRevision, err = controllerHistory.UpdateControllerRevision(
+			equalRevisions[equalCount-1],
+			nextRevision.Revision)
+		if err != nil {
+			return err
+		}
+	} else {
+		//if there is no equivalent revision we create a new one
+		nextRevision, err = controllerHistory.CreateControllerRevision(cluster, nextRevision, &collisionCount)
+		if err != nil {
+			return err
+		}
+	}
+
+	// if the current revision is nil we initialize the history by setting it to the next revision
+	if recordedStatus.CurrentRevision == "" {
+		currentRevision = nextRevision
+		// attempt to find the revision that corresponds to the current revision
+	} else {
+		for i := range revisions {
+			if revisions[i].Name == getCurrentRevisionName(recordedStatus) {
+				currentRevision = revisions[i]
+				break
+			}
+		}
+	}
+	if currentRevision == nil {
+		return fmt.Errorf("current ControlRevision resoucre not found")
+	}
+
+	// update revision status
+	revisionStatus = new(RevisionStatus)
+	revisionStatus.currentRevision = currentRevision.DeepCopy()
+	revisionStatus.nextRevision = nextRevision.DeepCopy()
+	revisionStatus.collisionCount = collisionCount
+	observed.revisionStatus = revisionStatus
+
+	// maintain the revision history limit
+	err = observer.truncateHistory(observed, controllerHistory)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (observer *FlinkClusterHandlerV2) truncateHistory(observed *ObservedClusterState, controllerHistory history.Interface) error {
+	var cluster = observed.cluster
+	var revisions = observed.revisions
+	// TODO: default limit
+	var historyLimit int
+	if cluster.Spec.RevisionHistoryLimit != nil {
+		historyLimit = int(*cluster.Spec.RevisionHistoryLimit)
+	} else {
+		historyLimit = 10
+	}
+
+	nonLiveHistory := getNonLiveHistory(revisions, historyLimit)
+
+	// delete any non-live history to maintain the revision limit.
+	for i := 0; i < len(nonLiveHistory); i++ {
+		if err := controllerHistory.DeleteControllerRevision(nonLiveHistory[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ======================================================
+// Utils
+
+func (observed ObservedClusterState) isNewRevision() bool {
+	return observed.cluster.Status.CurrentRevision != observed.cluster.Status.NextRevision
+}
+
+func (observed ObservedClusterState) isClusterStopped() bool {
+	return observed.cluster.Status.State == v1beta1.ClusterStateStopped
+}
+
+func (observed ObservedClusterState) isComponentUpdated(component runtime.Object) bool {
+	// MUST: Add is new revision check
+	// if !isUpdateTriggered(cluster.Status) {
+	// 	return true
+	// }
+	switch o := component.(type) {
+	case *appsv1.Deployment:
+		if o == nil {
+			return false
+		}
+	case *appsv1.StatefulSet:
+		if o == nil {
+			return false
+		}
+	case *corev1.ConfigMap:
+		if o == nil {
+			return false
+		}
+	case *corev1.Service:
+		if o == nil {
+			return false
+		}
+	case *batchv1.Job:
+		if o == nil {
+			return observed.cluster.Spec.Job == nil
+		}
+	case *extensionsv1beta1.Ingress:
+		if o == nil {
+			return observed.cluster.Spec.JobManager.Ingress == nil
+		}
+	}
+
+	var labels, err = meta.NewAccessor().Labels(component)
+	var nextRevisionName = getNextRevisionName(observed.cluster.Status)
+
+	if err != nil {
+		return false
+	}
+
+	return labels[RevisionNameLabel] == nextRevisionName
+}
+
+func (observed ObservedClusterState) isJobStopped() bool {
+	status := observed.cluster.Status.Components.Job
+	return status != nil &&
+		(status.State == v1beta1.JobStateSucceeded ||
+			status.State == v1beta1.JobStateFailed ||
+			status.State == v1beta1.JobStateCancelled ||
+			status.State == v1beta1.JobStateSuspended ||
+			status.State == v1beta1.JobStateLost)
+}
+
+func (observed ObservedClusterState) isJobUpdating() bool {
+	return observed.cluster.Status.Components.Job != nil &&
+		observed.cluster.Status.Components.Job.State == v1beta1.JobStateUpdating
+}
+
+// Gets Flink job ID based on the observed state and the recorded state.
+//
+// It is possible that the recorded is not nil, but the observed is, due
+// to transient error or being skiped as an optimization.
+// If this returned nil, it is the state that job is not submitted or not identified yet.
+func (observed ObservedClusterState) getFlinkJobId() *string {
+	var observedFlinkJob = observed.flinkJobStatus.flinkJob
+	if observedFlinkJob != nil && len(observedFlinkJob.Id) > 0 {
+		return &observedFlinkJob.Id
+	}
+
+	// Observed from job submitter (when job manager is not ready yet)
+	var observedJobSubmitLog = observed.flinkJobSubmitLog
+	if observedJobSubmitLog != nil && observedJobSubmitLog.JobID != "" {
+		return &observedJobSubmitLog.JobID
+	}
+
+	// Recorded.
+	var recordedJobStatus = observed.cluster.Status.Components.Job
+	if recordedJobStatus != nil && len(recordedJobStatus.ID) > 0 {
+		return &recordedJobStatus.ID
+	}
+
+	return nil
+}
+
+// Checks whether the component should be deleted according to the cleanup
+// policy. Always return false for session cluster.
+func (observed ObservedClusterState) shouldCleanup(cluster *v1beta1.FlinkCluster, component string) bool {
+	var jobStatus = cluster.Status.Components.Job
+
+	// Session cluster.
+	if jobStatus == nil {
+		return false
+	}
+
+	if isUpdateTriggered(cluster.Status) {
+		return false
+	}
+
+	var action v1beta1.CleanupAction
+	switch jobStatus.State {
+	case v1beta1.JobStateSucceeded:
+		action = cluster.Spec.Job.CleanupPolicy.AfterJobSucceeds
+	case v1beta1.JobStateFailed, v1beta1.JobStateLost:
+		action = cluster.Spec.Job.CleanupPolicy.AfterJobFails
+	case v1beta1.JobStateCancelled:
+		action = cluster.Spec.Job.CleanupPolicy.AfterJobCancelled
+	default:
+		return false
+	}
+
+	switch action {
+	case v1beta1.CleanupActionDeleteCluster:
+		return true
+	case v1beta1.CleanupActionDeleteTaskManager:
+		return component == "TaskManagerStatefulSet"
+	}
+
+	return false
+}

--- a/controllers/flinkcluster_v2_updater.go
+++ b/controllers/flinkcluster_v2_updater.go
@@ -53,7 +53,7 @@ func (updater *FlinkClusterHandlerV2) updateStatusIfChanged(ctx context.Context,
 	var changed = false
 	if diff := cmp.Diff(oldStatus, newStatus); diff != "" {
 		updater.log.Info("Status changed")
-		// updater.log.Info("Status diff", "diff", diff)
+		updater.log.Info("Status diff", "diff", diff)
 		changed = true
 	}
 
@@ -716,6 +716,8 @@ func (updater *FlinkClusterHandlerV2) deriveJobStatus(observed ObservedClusterSt
 				for _, e := range exceptions.Exceptions {
 					newJobStatus.FailureReasons = append(newJobStatus.FailureReasons, e.Exception)
 				}
+			} else {
+				newJobStatus.FailureReasons = append(newJobStatus.FailureReasons, "Failed to get job exceptions")
 			}
 			if observed.flinkJobSubmitLog != nil {
 				newJobStatus.FailureReasons = append(newJobStatus.FailureReasons, observed.flinkJobSubmitLog.Message)

--- a/controllers/flinkcluster_v2_updater.go
+++ b/controllers/flinkcluster_v2_updater.go
@@ -1,0 +1,858 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+// Updater which updates the status of a cluster based on the status of its
+// components.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/google/go-cmp/cmp"
+	v1beta1 "github.com/spotify/flink-on-k8s-operator/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Compares the current status recorded in the cluster's status field and the
+// new status derived from the status of the components, updates the cluster
+// status if it is changed, returns the new status.
+func (updater *FlinkClusterHandlerV2) updateStatusIfChanged(ctx context.Context, observed ObservedClusterState) (bool, error) {
+	if observed.cluster == nil {
+		updater.log.Info("The cluster has been deleted, no status to update")
+		return false, nil
+	}
+
+	// Current status recorded in the cluster's status field.
+	var oldStatus = v1beta1.FlinkClusterStatus{}
+	observed.cluster.Status.DeepCopyInto(&oldStatus)
+	oldStatus.LastUpdateTime = ""
+
+	// New status derived from the cluster's components.
+	var newStatus = updater.deriveClusterStatus(observed)
+
+	var changed = false
+	if diff := cmp.Diff(oldStatus, newStatus); diff != "" {
+		updater.log.Info("Status changed")
+		// updater.log.Info("Status diff", "diff", diff)
+		changed = true
+	}
+
+	// Update
+	if changed {
+		updater.createStatusChangeEvents(observed, oldStatus, newStatus)
+		var tc = &TimeConverter{}
+		newStatus.LastUpdateTime = tc.ToString(time.Now())
+		return true, updater.updateClusterStatus(ctx, observed, newStatus)
+	} else {
+		updater.log.Info("No status change", "state", oldStatus.State)
+		return false, nil
+	}
+}
+
+func (updater *FlinkClusterHandlerV2) createStatusChangeEvents(observed ObservedClusterState, oldStatus v1beta1.FlinkClusterStatus, newStatus v1beta1.FlinkClusterStatus) {
+	if oldStatus.Components.JobManagerStatefulSet.State !=
+		newStatus.Components.JobManagerStatefulSet.State {
+		updater.createStatusChangeEvent(
+			observed,
+			"JobManager StatefulSet",
+			oldStatus.Components.JobManagerStatefulSet.State,
+			newStatus.Components.JobManagerStatefulSet.State)
+	}
+
+	// ConfigMap.
+	if oldStatus.Components.ConfigMap.State !=
+		newStatus.Components.ConfigMap.State {
+		updater.createStatusChangeEvent(
+			observed,
+			"ConfigMap",
+			oldStatus.Components.ConfigMap.State,
+			newStatus.Components.ConfigMap.State)
+	}
+
+	// JobManager service.
+	if oldStatus.Components.JobManagerService.State !=
+		newStatus.Components.JobManagerService.State {
+		updater.createStatusChangeEvent(
+			observed,
+			"JobManager service",
+			oldStatus.Components.JobManagerService.State,
+			newStatus.Components.JobManagerService.State)
+	}
+
+	// JobManager ingress.
+	if oldStatus.Components.JobManagerIngress == nil && newStatus.Components.JobManagerIngress != nil {
+		updater.createStatusChangeEvent(
+			observed,
+			"JobManager ingress",
+			"",
+			newStatus.Components.JobManagerIngress.State)
+	}
+	if oldStatus.Components.JobManagerIngress != nil && newStatus.Components.JobManagerIngress != nil &&
+		oldStatus.Components.JobManagerIngress.State != newStatus.Components.JobManagerIngress.State {
+		updater.createStatusChangeEvent(
+			observed,
+			"JobManager ingress",
+			oldStatus.Components.JobManagerIngress.State,
+			newStatus.Components.JobManagerIngress.State)
+	}
+
+	// TaskManager.
+	if oldStatus.Components.TaskManagerStatefulSet.State !=
+		newStatus.Components.TaskManagerStatefulSet.State {
+		updater.createStatusChangeEvent(
+			observed,
+			"TaskManager StatefulSet",
+			oldStatus.Components.TaskManagerStatefulSet.State,
+			newStatus.Components.TaskManagerStatefulSet.State)
+	}
+
+	// Job.
+	if oldStatus.Components.Job == nil && newStatus.Components.Job != nil {
+		updater.createStatusChangeEvent(
+			observed,
+			"Job",
+			"",
+			newStatus.Components.Job.State)
+	}
+	if oldStatus.Components.Job != nil && newStatus.Components.Job != nil &&
+		oldStatus.Components.Job.State != newStatus.Components.Job.State {
+		updater.createStatusChangeEvent(
+			observed,
+			"Job",
+			oldStatus.Components.Job.State,
+			newStatus.Components.Job.State)
+	}
+
+	// Cluster.
+	if oldStatus.State != newStatus.State {
+		updater.createStatusChangeEvent(
+			observed,
+			"Cluster",
+			oldStatus.State,
+			newStatus.State)
+	}
+
+	// Savepoint.
+	if newStatus.Savepoint != nil && !reflect.DeepEqual(oldStatus.Savepoint, newStatus.Savepoint) {
+		eventType, eventReason, eventMessage := getSavepointEvent(*newStatus.Savepoint)
+		updater.recorder.Event(observed.cluster, eventType, eventReason, eventMessage)
+	}
+
+	// Control.
+	if newStatus.Control != nil && !reflect.DeepEqual(oldStatus.Control, newStatus.Control) {
+		eventType, eventReason, eventMessage := getControlEvent(*newStatus.Control)
+		updater.recorder.Event(observed.cluster, eventType, eventReason, eventMessage)
+	}
+}
+
+func (updater *FlinkClusterHandlerV2) createStatusChangeEvent(observed ObservedClusterState, name string, oldStatus string, newStatus string) {
+	if len(oldStatus) == 0 {
+		updater.recorder.Event(
+			observed.cluster,
+			corev1.EventTypeNormal,
+			"StatusUpdate",
+			fmt.Sprintf("%v status: %v", name, newStatus))
+	} else {
+		updater.recorder.Event(
+			observed.cluster,
+			corev1.EventTypeNormal,
+			"StatusUpdate",
+			fmt.Sprintf("%v status changed: %v -> %v", name, oldStatus, newStatus))
+	}
+}
+
+func (updater *FlinkClusterHandlerV2) deriveClusterStatus(observed ObservedClusterState) v1beta1.FlinkClusterStatus {
+	recorded := observed.cluster.Status
+
+	var status = v1beta1.FlinkClusterStatus{}
+	var runningComponents = 0
+	// jmStatefulSet, jmService, tmStatefulSet.
+	var totalComponents = 3
+	var updateState = getUpdateState(observed)
+	var isClusterUpdating = !isClusterUpdateToDate(observed) && updateState == UpdateStateInProgress
+	var isJobUpdating = recorded.Components.Job != nil && recorded.Components.Job.State == v1beta1.JobStateUpdating
+
+	// ConfigMap.
+	status.Components.ConfigMap = updater.deriveConfigMapStatus(observed)
+
+	// JobManager StatefulSet.
+	var observedJmStatefulSet = observed.jmStatefulSet
+	if !isComponentUpdated(observedJmStatefulSet, *observed.cluster) && isJobUpdating {
+		recorded.Components.JobManagerStatefulSet.DeepCopyInto(&status.Components.JobManagerStatefulSet)
+		status.Components.JobManagerStatefulSet.State = v1beta1.ComponentStateUpdating
+	} else if observedJmStatefulSet != nil {
+		status.Components.JobManagerStatefulSet.Name = observedJmStatefulSet.Name
+		status.Components.JobManagerStatefulSet.State = getStatefulSetState(observedJmStatefulSet)
+		if status.Components.JobManagerStatefulSet.State == v1beta1.ComponentStateReady {
+			runningComponents++
+		}
+	} else if recorded.Components.JobManagerStatefulSet.Name != "" {
+		status.Components.JobManagerStatefulSet =
+			v1beta1.FlinkClusterComponentState{
+				Name:  recorded.Components.JobManagerStatefulSet.Name,
+				State: v1beta1.ComponentStateDeleted,
+			}
+	}
+
+	// JobManager service.
+	var observedJmService = observed.jmService
+	if !isComponentUpdated(observedJmService, *observed.cluster) && isJobUpdating {
+		recorded.Components.JobManagerService.DeepCopyInto(&status.Components.JobManagerService)
+		status.Components.JobManagerService.State = v1beta1.ComponentStateUpdating
+	} else if observedJmService != nil {
+		var nodePort int32
+		var loadBalancerIngress []corev1.LoadBalancerIngress
+		state := v1beta1.ComponentStateNotReady
+
+		switch observedJmService.Spec.Type {
+		case corev1.ServiceTypeClusterIP:
+			if observedJmService.Spec.ClusterIP != "" {
+				state = v1beta1.ComponentStateReady
+				runningComponents++
+			}
+		case corev1.ServiceTypeLoadBalancer:
+			if len(observedJmService.Status.LoadBalancer.Ingress) > 0 {
+				state = v1beta1.ComponentStateReady
+				runningComponents++
+				loadBalancerIngress = observedJmService.Status.LoadBalancer.Ingress
+			}
+		case corev1.ServiceTypeNodePort:
+			if len(observedJmService.Spec.Ports) > 0 {
+				state = v1beta1.ComponentStateReady
+				runningComponents++
+				for _, port := range observedJmService.Spec.Ports {
+					if port.Name == "ui" {
+						nodePort = port.NodePort
+					}
+				}
+			}
+		}
+
+		status.Components.JobManagerService =
+			v1beta1.JobManagerServiceStatus{
+				Name:                observedJmService.Name,
+				State:               state,
+				NodePort:            nodePort,
+				LoadBalancerIngress: loadBalancerIngress,
+			}
+	} else if recorded.Components.JobManagerService.Name != "" {
+		status.Components.JobManagerService =
+			v1beta1.JobManagerServiceStatus{
+				Name:  recorded.Components.JobManagerService.Name,
+				State: v1beta1.ComponentStateDeleted,
+			}
+	}
+
+	// (Optional) JobManager ingress.
+	var observedJmIngress = observed.jmIngress
+	if !isComponentUpdated(observedJmIngress, *observed.cluster) && isJobUpdating {
+		status.Components.JobManagerIngress = &v1beta1.JobManagerIngressStatus{}
+		recorded.Components.JobManagerIngress.DeepCopyInto(status.Components.JobManagerIngress)
+		status.Components.JobManagerIngress.State = v1beta1.ComponentStateUpdating
+	} else if observedJmIngress != nil {
+		var state string
+		var urls []string
+		var useTLS bool
+		var useHost bool
+		var loadbalancerReady bool
+
+		if len(observedJmIngress.Spec.TLS) > 0 {
+			useTLS = true
+		}
+
+		if useTLS {
+			for _, tls := range observedJmIngress.Spec.TLS {
+				for _, host := range tls.Hosts {
+					if host != "" {
+						urls = append(urls, "https://"+host)
+					}
+				}
+			}
+		} else {
+			for _, rule := range observedJmIngress.Spec.Rules {
+				if rule.Host != "" {
+					urls = append(urls, "http://"+rule.Host)
+				}
+			}
+		}
+		if len(urls) > 0 {
+			useHost = true
+		}
+
+		// Check loadbalancer is ready.
+		if len(observedJmIngress.Status.LoadBalancer.Ingress) > 0 {
+			var addr string
+			for _, ingress := range observedJmIngress.Status.LoadBalancer.Ingress {
+				// Get loadbalancer address.
+				if ingress.Hostname != "" {
+					addr = ingress.Hostname
+				} else if ingress.IP != "" {
+					addr = ingress.IP
+				}
+				// If ingress spec does not have host, get ip or hostname of loadbalancer.
+				if !useHost && addr != "" {
+					if useTLS {
+						urls = append(urls, "https://"+addr)
+					} else {
+						urls = append(urls, "http://"+addr)
+					}
+				}
+			}
+			// If any ready LB found, state is ready.
+			if addr != "" {
+				loadbalancerReady = true
+			}
+		}
+
+		// Jobmanager ingress state become ready when LB for ingress is specified.
+		if loadbalancerReady {
+			state = v1beta1.ComponentStateReady
+		} else {
+			state = v1beta1.ComponentStateNotReady
+		}
+
+		status.Components.JobManagerIngress =
+			&v1beta1.JobManagerIngressStatus{
+				Name:  observedJmIngress.Name,
+				State: state,
+				URLs:  urls,
+			}
+	} else if recorded.Components.JobManagerIngress != nil &&
+		recorded.Components.JobManagerIngress.Name != "" {
+		status.Components.JobManagerIngress =
+			&v1beta1.JobManagerIngressStatus{
+				Name:  recorded.Components.JobManagerIngress.Name,
+				State: v1beta1.ComponentStateDeleted,
+			}
+	}
+
+	// TaskManager StatefulSet.
+	var observedTmStatefulSet = observed.tmStatefulSet
+	if !isComponentUpdated(observedTmStatefulSet, *observed.cluster) && isJobUpdating {
+		recorded.Components.TaskManagerStatefulSet.DeepCopyInto(&status.Components.TaskManagerStatefulSet)
+		status.Components.TaskManagerStatefulSet.State = v1beta1.ComponentStateUpdating
+	} else if observedTmStatefulSet != nil {
+		status.Components.TaskManagerStatefulSet.Name =
+			observedTmStatefulSet.Name
+		status.Components.TaskManagerStatefulSet.State =
+			getStatefulSetState(observedTmStatefulSet)
+		if status.Components.TaskManagerStatefulSet.State ==
+			v1beta1.ComponentStateReady {
+			runningComponents++
+		}
+	} else if recorded.Components.TaskManagerStatefulSet.Name != "" {
+		status.Components.TaskManagerStatefulSet =
+			v1beta1.FlinkClusterComponentState{
+				Name:  recorded.Components.TaskManagerStatefulSet.Name,
+				State: v1beta1.ComponentStateDeleted,
+			}
+	}
+
+	// (Optional) Job.
+	var jobStatus = updater.deriveJobStatus(observed)
+	status.Components.Job = jobStatus
+
+	// Derive the new cluster state.
+	switch recorded.State {
+	case "", v1beta1.ClusterStateCreating:
+		if runningComponents < totalComponents {
+			status.State = v1beta1.ClusterStateCreating
+			if isJobStopped(jobStatus) {
+				var policy = observed.cluster.Spec.Job.CleanupPolicy
+				if jobStatus.State == v1beta1.JobStateSucceeded &&
+					policy.AfterJobSucceeds != v1beta1.CleanupActionKeepCluster {
+					status.State = v1beta1.ClusterStateStopping
+				} else if jobStatus.State == v1beta1.JobStateFailed &&
+					policy.AfterJobFails != v1beta1.CleanupActionKeepCluster {
+					status.State = v1beta1.ClusterStateStopping
+				} else if jobStatus.State == v1beta1.JobStateCancelled &&
+					policy.AfterJobCancelled != v1beta1.CleanupActionKeepCluster {
+					status.State = v1beta1.ClusterStateStopping
+				}
+			}
+		} else {
+			status.State = v1beta1.ClusterStateRunning
+		}
+	case v1beta1.ClusterStateUpdating:
+		if isClusterUpdating {
+			status.State = v1beta1.ClusterStateUpdating
+		} else if runningComponents < totalComponents {
+			if isUpdateTriggered(recorded) {
+				status.State = v1beta1.ClusterStateUpdating
+			} else {
+				status.State = v1beta1.ClusterStateReconciling
+			}
+		} else {
+			status.State = v1beta1.ClusterStateRunning
+		}
+	case v1beta1.ClusterStateRunning,
+		v1beta1.ClusterStateReconciling:
+		if isClusterUpdating {
+			status.State = v1beta1.ClusterStateUpdating
+		} else if isJobStopped(jobStatus) {
+			var policy = observed.cluster.Spec.Job.CleanupPolicy
+			if jobStatus.State == v1beta1.JobStateSucceeded &&
+				policy.AfterJobSucceeds != v1beta1.CleanupActionKeepCluster {
+				status.State = v1beta1.ClusterStateStopping
+			} else if jobStatus.State == v1beta1.JobStateFailed &&
+				policy.AfterJobFails != v1beta1.CleanupActionKeepCluster {
+				status.State = v1beta1.ClusterStateStopping
+			} else if jobStatus.State == v1beta1.JobStateCancelled &&
+				policy.AfterJobCancelled != v1beta1.CleanupActionKeepCluster {
+				status.State = v1beta1.ClusterStateStopping
+			} else {
+				status.State = v1beta1.ClusterStateRunning
+			}
+		} else if runningComponents < totalComponents {
+			status.State = v1beta1.ClusterStateReconciling
+		} else {
+			status.State = v1beta1.ClusterStateRunning
+		}
+	case v1beta1.ClusterStateStopping,
+		v1beta1.ClusterStatePartiallyStopped:
+		if isClusterUpdating {
+			status.State = v1beta1.ClusterStateUpdating
+		} else if runningComponents == 0 {
+			status.State = v1beta1.ClusterStateStopped
+		} else if runningComponents < totalComponents {
+			status.State = v1beta1.ClusterStatePartiallyStopped
+		} else {
+			status.State = v1beta1.ClusterStateStopping
+		}
+	case v1beta1.ClusterStateStopped:
+		if isUpdateTriggered(recorded) {
+			status.State = v1beta1.ClusterStateUpdating
+		} else {
+			status.State = v1beta1.ClusterStateStopped
+		}
+	default:
+		panic(fmt.Sprintf("Unknown cluster state: %v", recorded.State))
+	}
+
+	// Savepoint status
+	// update savepoint status if it is in progress
+	if recorded.Savepoint != nil {
+		var newSavepointStatus = recorded.Savepoint.DeepCopy()
+		if recorded.Savepoint.State == v1beta1.SavepointStateInProgress && observed.savepoint != nil {
+			switch {
+			case observed.savepoint.IsSuccessful():
+				newSavepointStatus.State = v1beta1.SavepointStateSucceeded
+			case observed.savepoint.IsFailed():
+				var msg string
+				newSavepointStatus.State = v1beta1.SavepointStateFailed
+				if observed.savepoint.FailureCause.StackTrace != "" {
+					msg = fmt.Sprintf("Savepoint error: %v", observed.savepoint.FailureCause.StackTrace)
+				} else if observed.savepointErr != nil {
+					msg = fmt.Sprintf("Failed to get triggered savepoint status: %v", observed.savepointErr)
+				} else {
+					msg = "Failed to get triggered savepoint status"
+				}
+				if len(msg) > 1024 {
+					msg = msg[:1024] + "..."
+				}
+				newSavepointStatus.Message = msg
+				// TODO: organize more making savepoint status
+				if newSavepointStatus.TriggerReason == v1beta1.SavepointTriggerReasonUpdate {
+					newSavepointStatus.Message =
+						"Failed to take savepoint for update. " +
+							"The update process is being postponed until a savepoint is available. " + newSavepointStatus.Message
+				}
+			}
+		}
+		if newSavepointStatus.State == v1beta1.SavepointStateNotTriggered || newSavepointStatus.State == v1beta1.SavepointStateInProgress {
+			var flinkJobID = observed.getFlinkJobId()
+			switch {
+			case savepointTimeout(newSavepointStatus):
+				newSavepointStatus.State = v1beta1.SavepointStateFailed
+				newSavepointStatus.Message = "Timed out taking savepoint."
+			case isJobStopped(recorded.Components.Job):
+				newSavepointStatus.Message = "Flink job is stopped."
+				newSavepointStatus.State = v1beta1.SavepointStateFailed
+			case observed.flinkJobStatus.flinkJobList == nil:
+				newSavepointStatus.Message = "Flink API is not available."
+				newSavepointStatus.State = v1beta1.SavepointStateFailed
+			case flinkJobID == nil:
+				newSavepointStatus.Message = "Flink job is not submitted or identified."
+				newSavepointStatus.State = v1beta1.SavepointStateFailed
+			case flinkJobID != nil && (recorded.Savepoint.TriggerID != "" && *flinkJobID != recorded.Savepoint.JobID):
+				newSavepointStatus.Message = "Savepoint triggered Flink job is lost."
+				newSavepointStatus.State = v1beta1.SavepointStateFailed
+			}
+			// TODO: organize more making savepoint status
+			if newSavepointStatus.State == v1beta1.SavepointStateFailed &&
+				newSavepointStatus.TriggerReason == v1beta1.SavepointTriggerReasonUpdate {
+				newSavepointStatus.Message =
+					"Failed to take savepoint for update. " +
+						"The update process is being postponed until a savepoint is available. " + newSavepointStatus.Message
+			}
+		}
+		status.Savepoint = newSavepointStatus
+	}
+
+	// User requested control
+	var userControl = observed.cluster.Annotations[v1beta1.ControlAnnotation]
+
+	// Update job control status in progress
+	var controlStatus *v1beta1.FlinkClusterControlStatus
+	if recorded.Control != nil && userControl == recorded.Control.Name &&
+		recorded.Control.State == v1beta1.ControlStateProgressing {
+		controlStatus = recorded.Control.DeepCopy()
+		var savepointStatus = status.Savepoint
+		switch recorded.Control.Name {
+		case v1beta1.ControlNameJobCancel:
+			if status.Components.Job.State == v1beta1.JobStateCancelled {
+				controlStatus.State = v1beta1.ControlStateSucceeded
+				setTimestamp(&controlStatus.UpdateTime)
+			} else if isJobTerminated(observed.cluster.Spec.Job.RestartPolicy, recorded.Components.Job) {
+				controlStatus.Message = "Aborted job cancellation: Job is terminated."
+				controlStatus.State = v1beta1.ControlStateFailed
+				setTimestamp(&controlStatus.UpdateTime)
+			} else if savepointStatus != nil && savepointStatus.State == v1beta1.SavepointStateFailed {
+				controlStatus.Message = "Aborted job cancellation: failed to create savepoint."
+				controlStatus.State = v1beta1.ControlStateFailed
+				setTimestamp(&controlStatus.UpdateTime)
+			} else if recorded.Control.Message != "" {
+				controlStatus.State = v1beta1.ControlStateFailed
+				setTimestamp(&controlStatus.UpdateTime)
+			}
+		case v1beta1.ControlNameSavepoint:
+			if savepointStatus != nil {
+				switch savepointStatus.State {
+				case v1beta1.SavepointStateSucceeded:
+					controlStatus.State = v1beta1.ControlStateSucceeded
+					setTimestamp(&controlStatus.UpdateTime)
+				case v1beta1.SavepointStateFailed, v1beta1.SavepointStateTriggerFailed:
+					controlStatus.State = v1beta1.ControlStateFailed
+					setTimestamp(&controlStatus.UpdateTime)
+				}
+			}
+		}
+		// aborted by max retry reach
+		var retries = controlStatus.Details[ControlRetries]
+		if retries == ControlMaxRetries {
+			controlStatus.Message = fmt.Sprintf("Aborted control %v. The maximum number of retries has been reached.", controlStatus.Name)
+			controlStatus.State = v1beta1.ControlStateFailed
+			setTimestamp(&controlStatus.UpdateTime)
+		}
+	} else if userControl != "" {
+		// Handle new user control.
+		updater.log.Info("New user control requested: " + userControl)
+		if userControl != v1beta1.ControlNameJobCancel && userControl != v1beta1.ControlNameSavepoint {
+			if userControl != "" {
+				updater.log.Info(fmt.Sprintf(v1beta1.InvalidControlAnnMsg, v1beta1.ControlAnnotation, userControl))
+			}
+		} else if recorded.Control != nil && recorded.Control.State == v1beta1.ControlStateProgressing {
+			updater.log.Info(fmt.Sprintf(v1beta1.ControlChangeWarnMsg, v1beta1.ControlAnnotation), "current control", recorded.Control.Name, "new control", userControl)
+		} else {
+			switch userControl {
+			case v1beta1.ControlNameSavepoint:
+				if observed.cluster.Spec.Job.SavepointsDir == nil || *observed.cluster.Spec.Job.SavepointsDir == "" {
+					updater.log.Info(fmt.Sprintf(v1beta1.InvalidSavepointDirMsg, v1beta1.ControlAnnotation))
+					break
+				} else if isJobStopped(observed.cluster.Status.Components.Job) {
+					updater.log.Info(fmt.Sprintf(v1beta1.InvalidJobStateForSavepointMsg, v1beta1.ControlAnnotation))
+					break
+				}
+				// Clear status for new savepoint
+				status.Savepoint = getRequestedSavepointStatus(v1beta1.SavepointTriggerReasonUserRequested)
+				controlStatus = getNewUserControlStatus(userControl)
+			case v1beta1.ControlNameJobCancel:
+				if isJobTerminated(observed.cluster.Spec.Job.RestartPolicy, recorded.Components.Job) {
+					updater.log.Info(fmt.Sprintf(v1beta1.InvalidJobStateForJobCancelMsg, v1beta1.ControlAnnotation))
+					break
+				}
+				// Savepoint for job-cancel
+				var observedSavepoint = observed.cluster.Status.Savepoint
+				if observedSavepoint == nil ||
+					(observedSavepoint.State != v1beta1.SavepointStateInProgress && observedSavepoint.State != v1beta1.SavepointStateNotTriggered) {
+					updater.log.Info("There is no savepoint in progress. Trigger savepoint in reconciler.")
+					status.Savepoint = getRequestedSavepointStatus(v1beta1.SavepointTriggerReasonJobCancel)
+				} else {
+					updater.log.Info("There is a savepoint in progress. Skip new savepoint.")
+				}
+				controlStatus = getNewUserControlStatus(userControl)
+			}
+		}
+	}
+	// Maintain control status if there is no change.
+	if recorded.Control != nil && controlStatus == nil {
+		controlStatus = recorded.Control.DeepCopy()
+	}
+	status.Control = controlStatus
+
+	// Handle update.
+	var savepointForJobUpdate *v1beta1.SavepointStatus
+	switch updateState {
+	case UpdateStatePreparing:
+		// Even if savepoint has been created for update already, we check the age of savepoint continually.
+		// If created savepoint is old and savepoint can be triggered, we should take savepoint again.
+		// (e.g., for the case update is not progressed by accidents like network partition)
+		if !isSavepointUpToDate(observed.observeTime, *jobStatus) &&
+			canTakeSavepoint(*observed.cluster) &&
+			(recorded.Savepoint == nil || recorded.Savepoint.State != v1beta1.SavepointStateNotTriggered) {
+			// If failed to take savepoint, retry after SavepointRequestRetryIntervalSec.
+			if recorded.Savepoint != nil &&
+				!hasTimeElapsed(recorded.Savepoint.RequestTime, time.Now(), SavepointRequestRetryIntervalSec) {
+				updater.log.Info(fmt.Sprintf("Will retry to trigger savepoint for update, in %v seconds because previous request was failed", SavepointRequestRetryIntervalSec))
+			} else {
+				status.Savepoint = getRequestedSavepointStatus(v1beta1.SavepointTriggerReasonUpdate)
+				updater.log.Info("Savepoint will be triggered for update")
+			}
+		} else if recorded.Savepoint != nil && recorded.Savepoint.State == v1beta1.SavepointStateInProgress {
+			updater.log.Info("Savepoint for update is in progress")
+		} else {
+			updater.log.Info("Stopping job for update")
+		}
+	case UpdateStateInProgress:
+		updater.log.Info("Updating cluster")
+	case UpdateStateFinished:
+		status.CurrentRevision = observed.cluster.Status.NextRevision
+		updater.log.Info("Finished update")
+	}
+	if savepointForJobUpdate != nil {
+		status.Savepoint = savepointForJobUpdate
+	}
+
+	// Update revision status
+	status.NextRevision = getRevisionWithNameNumber(observed.revisionStatus.nextRevision)
+	if status.CurrentRevision == "" {
+		if recorded.CurrentRevision == "" {
+			status.CurrentRevision = getRevisionWithNameNumber(observed.revisionStatus.currentRevision)
+		} else {
+			status.CurrentRevision = recorded.CurrentRevision
+		}
+	}
+	if observed.revisionStatus.collisionCount != 0 {
+		status.CollisionCount = new(int32)
+		*status.CollisionCount = observed.revisionStatus.collisionCount
+	}
+
+	return status
+}
+
+func (updater *FlinkClusterHandlerV2) deriveConfigMapStatus(observed ObservedClusterState) v1beta1.FlinkClusterComponentState {
+	var observedConfigMap = observed.configMap
+	if observed.configMap == nil {
+		if observed.cluster.Status.Components.ConfigMap.Name != "" {
+			return v1beta1.FlinkClusterComponentState{
+				Name:  observed.cluster.Status.Components.ConfigMap.Name,
+				State: v1beta1.ComponentStateDeleted,
+			}
+		} else {
+			return v1beta1.FlinkClusterComponentState{
+				State: v1beta1.ComponentStateUpdating,
+			}
+		}
+	} else {
+		if !observed.isNewRevision() || !observed.isComponentUpdated(observedConfigMap) || !observed.isJobUpdating() {
+			return v1beta1.FlinkClusterComponentState{
+				Name:  observed.configMap.Name,
+				State: v1beta1.ComponentStateUpdating,
+			}
+		} else {
+			return v1beta1.FlinkClusterComponentState{
+				Name:  observed.configMap.Name,
+				State: v1beta1.ComponentStateReady,
+			}
+		}
+	}
+}
+
+func (updater *FlinkClusterHandlerV2) deriveJobStatus(observed ObservedClusterState) *v1beta1.JobStatus {
+	var observedJobStatus = observed.cluster.Status.Components.Job
+
+	if observedJobStatus == nil {
+		return nil
+	}
+
+	newJobStatus := observedJobStatus.DeepCopy()
+
+	// Flink Job ID
+	if observed.flinkJobStatus.flinkJob != nil {
+		newJobStatus.ID = observed.flinkJobStatus.flinkJob.Id
+		newJobStatus.Name = observed.flinkJobStatus.flinkJob.Name
+	}
+
+	if observed.job != nil {
+		newJobStatus.SubmitterName = observed.job.Name
+	}
+
+	// Update State
+	newJobStatus.State, newJobStatus.FailureReasons = updater.deriveJobStatusState(observed)
+
+	updater.log.Info("Job state", "jobstate", newJobStatus.State)
+
+	// Update Job Status info
+	if isJobStopped(newJobStatus) && newJobStatus.CompletionTime.IsZero() {
+		now := metav1.Now()
+		newJobStatus.CompletionTime = &now
+	}
+
+	if newJobStatus.State == v1beta1.JobStateFailed || newJobStatus.State == v1beta1.JobStateLost {
+		if len(newJobStatus.FailureReasons) == 0 {
+			newJobStatus.FailureReasons = []string{}
+			exceptions := observed.flinkJobStatus.flinkJobExceptions
+			if exceptions != nil && len(exceptions.Exceptions) > 0 {
+				for _, e := range exceptions.Exceptions {
+					newJobStatus.FailureReasons = append(newJobStatus.FailureReasons, e.Exception)
+				}
+			}
+			if observed.flinkJobSubmitLog != nil {
+				newJobStatus.FailureReasons = append(newJobStatus.FailureReasons, observed.flinkJobSubmitLog.Message)
+			}
+		}
+	}
+
+	// Savepoint
+	if observed.savepoint != nil && observed.savepoint.IsSuccessful() {
+		newJobStatus.SavepointGeneration++
+		newJobStatus.LastSavepointTriggerID = observed.savepoint.TriggerID
+		newJobStatus.SavepointLocation = observed.savepoint.Location
+		setTimestamp(&newJobStatus.LastSavepointTime)
+	}
+
+	return newJobStatus
+}
+
+func (updater *FlinkClusterHandlerV2) deriveJobStatusState(observed ObservedClusterState) (string, []string) {
+	var errorMessage []string
+
+	if observed.isNewRevision() {
+		if observed.flinkJobStatus.flinkJob == nil {
+			return v1beta1.JobStateUpdating, errorMessage
+		} else {
+			switch observed.flinkJobStatus.flinkJob.State {
+			case "INITIALIZING", "CREATED", "RUNNING", "FAILING", "CANCELLING", "RESTARTING", "RECONCILING":
+				return v1beta1.JobStateRunning, errorMessage
+			case "FINISHED", "CANCELED", "FAILED", "SUSPENDED":
+				return v1beta1.JobStateUpdating, errorMessage
+			default:
+				errorMessage = append(errorMessage, "Unknown flink job state")
+				return v1beta1.JobStateUnknown, errorMessage
+			}
+		}
+	} else {
+		if observed.flinkJobStatus.flinkJob == nil {
+			if observed.job == nil {
+				if shouldRestartJobV2(observed.cluster.Spec.Job.RestartPolicy, observed.cluster.Status.Components.Job) {
+					return v1beta1.JobStateUpdating, errorMessage
+				} else {
+					return observed.cluster.Status.Components.Job.State, observed.cluster.Status.Components.Job.FailureReasons
+				}
+			} else {
+				if observed.job.Status.Succeeded == 0 && observed.job.Status.Failed == 0 {
+					return v1beta1.JobStatePending, errorMessage
+				}
+				if observed.job.Status.Failed != 0 {
+					errorMessage = append(errorMessage, "Job pod failed")
+					return v1beta1.JobStateFailed, errorMessage
+				}
+				if observed.job.Status.Succeeded != 0 {
+					if observed.cluster.Status.Components.Job != nil && observed.cluster.Status.Components.Job.State == v1beta1.JobStateRunning {
+						errorMessage = append(errorMessage, "Missing flink job with successful submission")
+						return v1beta1.JobStateLost, errorMessage
+					}
+					if shouldRestartJobV2(observed.cluster.Spec.Job.RestartPolicy, observed.cluster.Status.Components.Job) {
+						return v1beta1.JobStateUpdating, errorMessage
+					}
+					// Return job state
+					return observed.cluster.Status.Components.Job.State, errorMessage
+				}
+				errorMessage = append(errorMessage, "Unknown job pod status")
+				return v1beta1.JobStateUnknown, errorMessage
+			}
+		} else {
+			switch observed.flinkJobStatus.flinkJob.State {
+			case "INITIALIZING", "CREATED", "RUNNING", "FAILING", "CANCELLING", "RESTARTING", "RECONCILING":
+				return v1beta1.JobStateRunning, errorMessage
+			case "FINISHED", "CANCELED", "FAILED", "SUSPENDED":
+				if observed.cluster.Status.Components.Job != nil && observed.cluster.Status.Components.Job.State == v1beta1.JobStateUpdating {
+					return v1beta1.JobStateUpdating, errorMessage
+				} else if observed.job != nil && observed.job.Status.Succeeded == 0 && observed.job.Status.Failed == 0 {
+					return v1beta1.JobStatePending, errorMessage
+				} else if observed.job != nil && observed.job.Status.Failed != 0 {
+					errorMessage = append(errorMessage, "Job pod failed")
+					return v1beta1.JobStateFailed, errorMessage
+				} else {
+					switch observed.flinkJobStatus.flinkJob.State {
+					case "FINISHED":
+						return v1beta1.JobStateSucceeded, errorMessage
+					case "CANCELED":
+						return v1beta1.JobStateCancelled, errorMessage
+					case "FAILED":
+						return v1beta1.JobStateFailed, errorMessage
+					case "SUSPENDED":
+						return v1beta1.JobStateSuspended, errorMessage
+					default:
+						// Impossible to reach, but required for compiler
+						errorMessage = append(errorMessage, "Unknown flink job state")
+						return v1beta1.JobStateUnknown, errorMessage
+					}
+				}
+			default:
+				errorMessage = append(errorMessage, "Unknown flink job state")
+				return v1beta1.JobStateUnknown, errorMessage
+			}
+		}
+	}
+}
+
+func (updater *FlinkClusterHandlerV2) updateClusterStatus(ctx context.Context, observed ObservedClusterState, status v1beta1.FlinkClusterStatus) error {
+	var cluster = v1beta1.FlinkCluster{}
+	observed.cluster.DeepCopyInto(&cluster)
+	cluster.Status = status
+
+	updater.log.Info("(FlinkClusterHandlerV2) Updating cluster status")
+
+	err := updater.k8sClient.Status().Update(ctx, &cluster)
+
+	// Clear control annotation after status update is complete.
+	updater.clearControlAnnotation(ctx, observed, status.Control)
+	return err
+}
+
+// Clear finished or improper user control in annotations
+func (updater *FlinkClusterHandlerV2) clearControlAnnotation(ctx context.Context, observed ObservedClusterState, newControlStatus *v1beta1.FlinkClusterControlStatus) error {
+	var userControl = observed.cluster.Annotations[v1beta1.ControlAnnotation]
+	if userControl == "" {
+		return nil
+	}
+	if newControlStatus == nil || userControl != newControlStatus.Name || // refused control in updater
+		(userControl == newControlStatus.Name && isUserControlFinished(newControlStatus)) /* finished control */ {
+		// make annotation patch cleared
+		annotationPatch := objectForPatch{
+			Metadata: objectMetaForPatch{
+				Annotations: map[string]interface{}{
+					v1beta1.ControlAnnotation: nil,
+				},
+			},
+		}
+		patchBytes, err := json.Marshal(&annotationPatch)
+		if err != nil {
+			return err
+		}
+		return updater.k8sClient.Patch(ctx, observed.cluster, client.RawPatch(types.MergePatchType, patchBytes))
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
-	github.com/google/uuid v1.1.2 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/json-iterator/go v1.1.11 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect

--- a/go.sum
+++ b/go.sum
@@ -210,8 +210,9 @@ github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hf
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=


### PR DESCRIPTION
@regadas @elanv  @clouddra this is my attempt to tidy up the implementation without creating breaking changes (hopefully)...

1. Changes flink cluster watch to only watch non status updates
2. Builds on the log parser to resolve job status
3. Reduces pointer usage in function parameters
4. Reduces logs that writes entire structs

I'm not sure how to switch the implementation used based on the spec in the controller, if you can help me with it that would be great!