### PR TITLE
Add connection timeout to job submitter script

### DIFF
--- a/controllers/flinkcluster_submit_job_script.go
+++ b/controllers/flinkcluster_submit_job_script.go
@@ -96,12 +96,13 @@ function check_jm_ready() {
     local -r MAX_RETRY=120
     local -r RETRY_INTERVAL=5s
     local -r REQUIRED_SUCCESS_NUMBER=3
+    local -r CONNECT_TIMEOUT=5
     local success_count=0
 
     echo_log "Checking job manager to be ready. Will check success of ${REQUIRED_SUCCESS_NUMBER} API calls for stable job submission." "job_check_log"
     for ((i = 1; i <= MAX_RETRY; i++)); do
         echo_log "curl -sS \"http://${FLINK_JM_ADDR}/jobs\"" "job_check_log"
-        if curl -sS "http://${FLINK_JM_ADDR}/jobs" 2>&1 | tee -a job_check_log; then
+        if curl -sS --connect-timeout ${CONNECT_TIMEOUT} "http://${FLINK_JM_ADDR}/jobs" 2>&1 | tee -a job_check_log; then
             ((success_count++))
             echo_log "\nSuccess ${success_count}/${REQUIRED_SUCCESS_NUMBER}" "job_check_log"
             if ((success_count < REQUIRED_SUCCESS_NUMBER)); then


### PR DESCRIPTION
When deploying a new cluster, the submitter is hanging by `curl -sS "http://jobmanager:8081/jobs"` for a long time until the default timeout of 120s because the jobmanager is not yet ready.

Adding `--connect-timeout <seconds>` to solve this problem.