### PR TITLE
Samples: Increase the resources so that the examples can run successfully

### DIFF
--- a/config/samples/flinkoperator_v1beta1_flinkjobcluster.yaml
+++ b/config/samples/flinkoperator_v1beta1_flinkjobcluster.yaml
@@ -40,4 +40,3 @@ spec:
     parallelism: 2
   flinkProperties:
     taskmanager.numberOfTaskSlots: "1"
-    taskmanager.memory.flink.size: "1024m"

--- a/config/samples/flinkoperator_v1beta1_flinkjobcluster.yaml
+++ b/config/samples/flinkoperator_v1beta1_flinkjobcluster.yaml
@@ -25,14 +25,14 @@ spec:
       ui: 8081
     resources:
       limits:
-        memory: "1024Mi"
-        cpu: "200m"
+        memory: "2048Mi"
+        cpu: "500m"
   taskManager:
     replicas: 2
     resources:
       limits:
-        memory: "1024Mi"
-        cpu: "200m"
+        memory: "2048Mi"
+        cpu: "500m"
   job:
     jarFile: ./examples/streaming/WordCount.jar
     className: org.apache.flink.streaming.examples.wordcount.WordCount
@@ -40,3 +40,4 @@ spec:
     parallelism: 2
   flinkProperties:
     taskmanager.numberOfTaskSlots: "1"
+    taskmanager.memory.flink.size: "1024m"

--- a/config/samples/flinkoperator_v1beta1_flinkjobcluster_volcano.yaml
+++ b/config/samples/flinkoperator_v1beta1_flinkjobcluster_volcano.yaml
@@ -27,14 +27,14 @@ spec:
       ui: 8081
     resources:
       limits:
-        memory: "1024Mi"
-        cpu: "200m"
+        memory: "2048Mi"
+        cpu: "500m"
   taskManager:
     replicas: 2
     resources:
       limits:
-        memory: "1024Mi"
-        cpu: "200m"
+        memory: "2048Mi"
+        cpu: "500m"
   job:
     jarFile: ./examples/streaming/WordCount.jar
     className: org.apache.flink.streaming.examples.wordcount.WordCount
@@ -43,3 +43,4 @@ spec:
     restartPolicy: Never
   flinkProperties:
     taskmanager.numberOfTaskSlots: "1"
+    taskmanager.memory.flink.size: "1024m"

--- a/config/samples/flinkoperator_v1beta1_flinkjobcluster_volcano.yaml
+++ b/config/samples/flinkoperator_v1beta1_flinkjobcluster_volcano.yaml
@@ -43,4 +43,3 @@ spec:
     restartPolicy: Never
   flinkProperties:
     taskmanager.numberOfTaskSlots: "1"
-    taskmanager.memory.flink.size: "1024m"

--- a/config/samples/flinkoperator_v1beta1_flinksessioncluster.yaml
+++ b/config/samples/flinkoperator_v1beta1_flinksessioncluster.yaml
@@ -55,4 +55,3 @@ spec:
       value: bar
   flinkProperties:
     taskmanager.numberOfTaskSlots: "1"
-    taskmanager.memory.flink.size: "1024m"

--- a/config/samples/flinkoperator_v1beta1_flinksessioncluster.yaml
+++ b/config/samples/flinkoperator_v1beta1_flinksessioncluster.yaml
@@ -30,14 +30,14 @@ spec:
       ui: 8081
     resources:
       limits:
-        memory: "1024Mi"
-        cpu: "200m"
+        memory: "2048Mi"
+        cpu: "500m"
   taskManager:
     replicas: 1
     resources:
       limits:
-        memory: "1024Mi"
-        cpu: "200m"
+        memory: "2048Mi"
+        cpu: "500m"
     volumes:
       - name: cache-volume
         emptyDir: {}
@@ -55,3 +55,4 @@ spec:
       value: bar
   flinkProperties:
     taskmanager.numberOfTaskSlots: "1"
+    taskmanager.memory.flink.size: "1024m"

--- a/config/samples/flinkoperator_v1beta1_flinksessioncluster_volcano.yaml
+++ b/config/samples/flinkoperator_v1beta1_flinksessioncluster_volcano.yaml
@@ -53,4 +53,3 @@ spec:
       value: bar
   flinkProperties:
     taskmanager.numberOfTaskSlots: "1"
-    taskmanager.memory.flink.size: "1024m"

--- a/config/samples/flinkoperator_v1beta1_flinksessioncluster_volcano.yaml
+++ b/config/samples/flinkoperator_v1beta1_flinksessioncluster_volcano.yaml
@@ -28,14 +28,14 @@ spec:
       ui: 8081
     resources:
       limits:
-        memory: "1024Mi"
-        cpu: "200m"
+        memory: "2048Mi"
+        cpu: "500m"
   taskManager:
     replicas: 1
     resources:
       limits:
-        memory: "1024Mi"
-        cpu: "200m"
+        memory: "2048Mi"
+        cpu: "500m"
     volumes:
       - name: cache-volume
         emptyDir: {}
@@ -53,3 +53,4 @@ spec:
       value: bar
   flinkProperties:
     taskmanager.numberOfTaskSlots: "1"
+    taskmanager.memory.flink.size: "1024m"


### PR DESCRIPTION
The current samples can't submit successfully because the memory exceeded the default limitation.
So that I increased the resources to make the samples can submit and run successfully.
