### PR TITLE
specify container name "main" to account for sidecar containers

### DIFF
--- a/controllers/flinkcluster_util.go
+++ b/controllers/flinkcluster_util.go
@@ -520,7 +520,7 @@ func getPodLogs(clientset *kubernetes.Clientset, pod *corev1.Pod) (string, error
 	}
 	pods := clientset.CoreV1().Pods(pod.Namespace)
 
-	req := pods.GetLogs(pod.Name, &corev1.PodLogOptions{})
+	req := pods.GetLogs(pod.Name, &corev1.PodLogOptions{Container: "main"})
 	podLogs, err := req.Stream(context.TODO())
 	if err != nil {
 		return "", fmt.Errorf("failed to get logs for pod %s: %v", pod.Name, err)


### PR DESCRIPTION
When running with injected sidecars (i.e. istio-proxy) pod.GetLogs requires a container name to be specified.

From https://pkg.go.dev/k8s.io/api/core/v1#PodLogOptions:
```go
type PodLogOptions struct {
	metav1.TypeMeta `json:",inline"`

	// The container for which to stream logs. Defaults to only container if there is one container in the pod.
	// +optional
	Container string `json:"container,omitempty" protobuf:"bytes,1,opt,name=container"`
```