### PR TITLE
Mount log conf to job-submitter

### DIFF
--- a/controllers/flinkcluster/flinkcluster_converter.go
+++ b/controllers/flinkcluster/flinkcluster_converter.go
@@ -1073,8 +1073,7 @@ func convertSubmitJobScript(clusterName string) (*corev1.Volume, *corev1.VolumeM
 	}
 	confMount := &corev1.VolumeMount{
 		Name:      flinkConfigMapVolume,
-		MountPath: path.Join(flinkConfigMapPath, "flink-conf.yaml"),
-		SubPath:   "flink-conf.yaml",
+		MountPath: flinkConfigMapPath,
 	}
 	return confVol, scriptMount, confMount
 }

--- a/controllers/flinkcluster/flinkcluster_converter_test.go
+++ b/controllers/flinkcluster/flinkcluster_converter_test.go
@@ -901,8 +901,7 @@ func TestGetDesiredClusterState(t *testing.T) {
 								},
 								{
 									Name:      "flink-config-volume",
-									MountPath: "/opt/flink/conf/flink-conf.yaml",
-									SubPath:   "flink-conf.yaml",
+									MountPath: "/opt/flink/conf",
 								},
 								{
 									Name:      "hadoop-config-volume",


### PR DESCRIPTION
This commit mounts the whole flinkConfigMapVolume to /opt/flink/conf at the job-submitter