### PR TITLE
Change the default ns from flink-operator-system to flink-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ IMG ?= ghcr.io/spotify/flink-operator:$(VERSION)
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:maxDescLen=0,trivialVersions=true,preserveUnknownFields=false,generateEmbeddedObjectMeta=true"
 # The Kubernetes namespace in which the operator will be deployed.
-FLINK_OPERATOR_NAMESPACE ?= flink-operator-system
+FLINK_OPERATOR_NAMESPACE ?= flink-operator
 # Prefix for Kubernetes resource names. When deploying multiple operators, make sure that the names of cluster-scoped resources are not duplicated.
 RESOURCE_PREFIX ?= flink-operator-
 # The Kubernetes namespace to limit watching.

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Adds namespace to all resources.
-namespace: flink-operator-system
+namespace: flink-operator
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -63,7 +63,7 @@ following 3 ways:
 
   - `IMG`: The Flink Operator image. The default value is `ghcr.io/spotify/flink-operator:latest`.
   - `FLINK_OPERATOR_NAMESPACE`: the namespace of the operator. The default value is
-    `flink-operator-system`.
+    `flink-operator`.
   - `RESOURCE_PREFIX`: the prefix to avoid conflict of cluster-scoped resources.
     The default value is `flink-operator-`.
   - `WATCH_NAMESPACE`: the namespace of the `FlinkCluster` CRs which the operator
@@ -98,19 +98,19 @@ kubectl describe crds/flinkclusters.flinkoperator.k8s.io
 Find out the deployment:
 
 ```bash
-kubectl get deployments -n flink-operator-system
+kubectl get deployments -n flink-operator
 ```
 
 Verify the operator Pod is up and running:
 
 ```bash
-kubectl get pods -n flink-operator-system
+kubectl get pods -n flink-operator
 ```
 
 Check the operator logs:
 
 ```bash
-kubectl logs -n flink-operator-system -l app=flink-operator --all-containers
+kubectl logs -n flink-operator -l app=flink-operator --all-containers
 ```
 
 you should be able see logs like:
@@ -239,7 +239,7 @@ There are several ways to submit jobs to a session cluster.
 You can check the operator logs with
 
 ```bash
-kubectl logs -n flink-operator-system -l app=flink-operator --all-containers -f --tail=1000
+kubectl logs -n flink-operator -l app=flink-operator --all-containers -f --tail=1000
 ```
 
 ### Flink cluster
@@ -496,5 +496,5 @@ Examples and explanations of the available options can be found [here](https://k
 ### Mounting external volumes to the pods
 
 If your deployment requires larger storage captivity, or a faster access to the state backend you can use `volumeClaimTemplates` option in TaskManager config
-to create a new claim template and then mount it in `volumeMounts`  
+to create a new claim template and then mount it in `volumeMounts`
 Check the [FlinkCluster Custom Resource Definition](./crd.md) and [StatefulSet's doc](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) for more info

--- a/helm-chart/flink-operator/README.md
+++ b/helm-chart/flink-operator/README.md
@@ -11,7 +11,7 @@ The instructions to install the Flink operator chart:
 2. Run the bash script `update_template.sh` to update the manifest files in templates from the Flink operator source repo (This step is only required if you want to install from the local chart repo).
     You can set the following env vars to customize the script's behaviour -
     * `export IMG=<image-name>` - Operator image, defaults to `flink-operator:latest`
-    * `export NS=<namespace-name>` - Namespace to install the operator in, defaults to `flink-operator-system`
+    * `export NS=<namespace-name>` - Namespace to install the operator in, defaults to `flink-operator`
 
 3. Register CRD - Don't manually register CRD unless helm install below fails (You can skip this step if your helm version is v3).
 

--- a/helm-chart/flink-operator/update_template.sh
+++ b/helm-chart/flink-operator/update_template.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 IMG="${IMG:-flink-operator:latest}"
-NS="${NS:-flink-operator-system}"
+NS="${NS:-flink-operator}"
 
 sed -e 's#image: .*#image: '"${IMG}"'#' ../../config/default/manager_image_patch.template >../../config/default/manager_image_patch.yaml
 sed -i '/- \.\.\/crd/d' ../../config/default/kustomization.yaml

--- a/helm-chart/flink-operator/values.yaml
+++ b/helm-chart/flink-operator/values.yaml
@@ -1,6 +1,6 @@
 # K8s namespace where Flink operator to be deployed
 flinkOperatorNamespace:
-  name: "flink-operator-system"
+  name: flink-operator
 
 # Watch custom resources in the namespace, ignore other namespaces. If empty, all namespaces will be watched.
 watchNamespace:


### PR DESCRIPTION
I think it's better to follow the Istio's style that runs `operator` in the namespace `istio-operator` and 
leaves the `istio-system` for the Istio instance.

The suffix `-system` seems redundant.

But maybe this could be thought as a broken change, 
so feel free to close this PR if you guys think this is dispensable. :)