### PR TITLE
Extract and expose the build Flink args logic

### DIFF
--- a/controllers/flinkcluster/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler.go
@@ -931,7 +931,7 @@ func (reconciler *ClusterReconciler) updateStatus(
 		if controlStatus != nil {
 			newStatus.Control = controlStatus
 		}
-		setTimestamp(&newStatus.LastUpdateTime)
+		SetTimestamp(&newStatus.LastUpdateTime)
 		log.Info("Updating cluster status", "clusterClone", clusterClone, "newStatus", newStatus)
 		statusUpdateErr = reconciler.k8sClient.Status().Update(reconciler.context, clusterClone)
 		if statusUpdateErr == nil {
@@ -966,8 +966,8 @@ func (reconciler *ClusterReconciler) updateJobDeployStatus() error {
 	newJob.CompletionTime = nil
 
 	// Mark as job submitter is deployed.
-	setTimestamp(&newJob.DeployTime)
-	setTimestamp(&clusterClone.Status.LastUpdateTime)
+	SetTimestamp(&newJob.DeployTime)
+	SetTimestamp(&clusterClone.Status.LastUpdateTime)
 
 	// Latest savepoint location should be fromSavepoint.
 	var fromSavepoint = getFromSavepoint(desiredJobSubmitter.Spec)
@@ -992,7 +992,7 @@ func (reconciler *ClusterReconciler) getNewSavepointStatus(triggerID string, tri
 	var jobID = reconciler.getFlinkJobID()
 	var savepointState string
 	var now string
-	setTimestamp(&now)
+	SetTimestamp(&now)
 
 	if triggerSuccess {
 		savepointState = v1beta1.SavepointStateInProgress

--- a/controllers/flinkcluster/flinkcluster_updater.go
+++ b/controllers/flinkcluster/flinkcluster_updater.go
@@ -632,7 +632,7 @@ func (updater *ClusterStatusUpdater) deriveJobStatus() *v1beta1.JobStatus {
 				newJob.RestartCount++
 			}
 		case newJob.State == v1beta1.JobStateRunning:
-			setTimestamp(&newJob.StartTime)
+			SetTimestamp(&newJob.StartTime)
 			newJob.CompletionTime = nil
 			// When job started, the savepoint is not the final state of the job any more.
 			if oldJob.FinalSavepoint {
@@ -675,7 +675,7 @@ func (updater *ClusterStatusUpdater) deriveJobStatus() *v1beta1.JobStatus {
 		// Currently savepoint complete timestamp is not included in savepoints API response.
 		// Whereas checkpoint API returns the timestamp latest_ack_timestamp.
 		// Note: https://ci.apache.org/projects/flink/flink-docs-stable/ops/rest_api.html#jobs-jobid-checkpoints-details-checkpointid
-		setTimestamp(&newJob.SavepointTime)
+		SetTimestamp(&newJob.SavepointTime)
 	}
 
 	return newJob
@@ -953,7 +953,7 @@ func deriveControlStatus(
 		}
 		// Update time when state changed.
 		if c.State != v1beta1.ControlStateInProgress {
-			setTimestamp(&c.UpdateTime)
+			SetTimestamp(&c.UpdateTime)
 		}
 		return c
 	}

--- a/controllers/flinkcluster/flinkcluster_util.go
+++ b/controllers/flinkcluster/flinkcluster_util.go
@@ -143,8 +143,8 @@ func (tc *TimeConverter) ToString(timestamp time.Time) string {
 	return timestamp.Format(time.RFC3339)
 }
 
-// setTimestamp sets the current timestamp to the target.
-func setTimestamp(target *string) {
+// SetTimestamp sets the current timestamp to the target.
+func SetTimestamp(target *string) {
 	var tc = &TimeConverter{}
 	var now = time.Now()
 	*target = tc.ToString(now)
@@ -292,7 +292,7 @@ func getControlStatus(controlName string, state string) *v1beta1.FlinkClusterCon
 	var controlStatus = new(v1beta1.FlinkClusterControlStatus)
 	controlStatus.Name = controlName
 	controlStatus.State = state
-	setTimestamp(&controlStatus.UpdateTime)
+	SetTimestamp(&controlStatus.UpdateTime)
 	return controlStatus
 }
 


### PR DESCRIPTION
Hi,
The reason for this is that I want to use the Operator to manage the Flink clusters, but I have some special business logic for the jobs.
So that I need to build and manage the jobs (PodSpec) by myself.
For the purpose to reuse the code as much as possible, I start to extract some logic into separate functions and expose as public.
On the other hand, I think this should also be beneficial for unit testing.