### PR TITLE
Helm charts: Add pdb for the operator

### DIFF
--- a/helm-chart/flink-operator/templates/pdb.yaml
+++ b/helm-chart/flink-operator/templates/pdb.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: flink-operator-pdb
+  namespace: {{ .Values.flinkOperatorNamespace.name }}
+spec:
+{{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+{{- else }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: flink-operator
+{{- end }}

--- a/helm-chart/flink-operator/values.yaml
+++ b/helm-chart/flink-operator/values.yaml
@@ -51,3 +51,8 @@ podAnnotations: {}
 
 nodeSelector: {}
 tolerations: {}
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 90%
+  maxUnavailable: 1


### PR DESCRIPTION
The reason that don't use `v1` is I want to support K8s `v1.19, v1.20`.
see https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125
We can upgrade 1Y+ later.