### PR TITLE
Add required fields to job cluster samples

### DIFF
--- a/config/samples/flinkoperator_v1beta1_flinkjobcluster.yaml
+++ b/config/samples/flinkoperator_v1beta1_flinkjobcluster.yaml
@@ -21,6 +21,7 @@ spec:
   image:
     name: flink:1.14.2
   jobManager:
+    accessScope: Cluster
     ports:
       ui: 8081
     resources:
@@ -38,5 +39,6 @@ spec:
     className: org.apache.flink.streaming.examples.wordcount.WordCount
     args: ["--input", "./README.txt"]
     parallelism: 2
+    restartPolicy: Never
   flinkProperties:
     taskmanager.numberOfTaskSlots: "1"


### PR DESCRIPTION
I found `flinkoperator_v1beta1_flinkjobcluster.yaml` and `flinkoperator_v1beta1_remotejobjar.yaml` missed required fields for v1beta1 `flinkclusters.flinkoperator.k8s.io`.