### PR TITLE
Add ability to add annotations and labels to JobManager service

### DIFF
--- a/apis/flinkcluster/v1beta1/flinkcluster_types.go
+++ b/apis/flinkcluster/v1beta1/flinkcluster_types.go
@@ -195,6 +195,9 @@ type JobManagerSpec struct {
 	// Currently `VPC, External` are only available for GKE.
 	AccessScope string `json:"accessScope,omitempty"`
 
+	// _(Optional)_ Define JobManager Service annotations for configuration.
+	ServiceAnnotations map[string]string `json:"ServiceAnnotations,omitempty"`
+
 	// _(Optional)_ Provide external access to JobManager UI/API.
 	Ingress *JobManagerIngressSpec `json:"ingress,omitempty"`
 

--- a/apis/flinkcluster/v1beta1/flinkcluster_types.go
+++ b/apis/flinkcluster/v1beta1/flinkcluster_types.go
@@ -198,6 +198,9 @@ type JobManagerSpec struct {
 	// _(Optional)_ Define JobManager Service annotations for configuration.
 	ServiceAnnotations map[string]string `json:"ServiceAnnotations,omitempty"`
 
+	// _(Optional)_ Define JobManager Service labels for configuration.
+	ServiceLabels map[string]string `json:"ServiceLabels,omitempty"`
+
 	// _(Optional)_ Provide external access to JobManager UI/API.
 	Ingress *JobManagerIngressSpec `json:"ingress,omitempty"`
 

--- a/apis/flinkcluster/v1beta1/zz_generated.deepcopy.go
+++ b/apis/flinkcluster/v1beta1/zz_generated.deepcopy.go
@@ -501,6 +501,13 @@ func (in *JobManagerSpec) DeepCopyInto(out *JobManagerSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.ServiceLabels != nil {
+		in, out := &in.ServiceLabels, &out.ServiceLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Ingress != nil {
 		in, out := &in.Ingress, &out.Ingress
 		*out = new(JobManagerIngressSpec)

--- a/apis/flinkcluster/v1beta1/zz_generated.deepcopy.go
+++ b/apis/flinkcluster/v1beta1/zz_generated.deepcopy.go
@@ -494,6 +494,13 @@ func (in *JobManagerSpec) DeepCopyInto(out *JobManagerSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.ServiceAnnotations != nil {
+		in, out := &in.ServiceAnnotations, &out.ServiceAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Ingress != nil {
 		in, out := &in.Ingress, &out.Ingress
 		*out = new(JobManagerIngressSpec)

--- a/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
+++ b/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
@@ -1651,6 +1651,10 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                    ServiceLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
                     accessScope:
                       type: string
                     extraPorts:

--- a/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
+++ b/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
@@ -1647,6 +1647,10 @@ spec:
                   type: object
                 jobManager:
                   properties:
+                    ServiceAnnotations:
+                      additionalProperties:
+                        type: string
+                      type: object
                     accessScope:
                       type: string
                     extraPorts:

--- a/controllers/flinkcluster/flinkcluster_converter.go
+++ b/controllers/flinkcluster/flinkcluster_converter.go
@@ -292,6 +292,7 @@ func newJobManagerService(flinkCluster *v1beta1.FlinkCluster) *corev1.Service {
 	switch jobManagerSpec.AccessScope {
 	case v1beta1.AccessScopeCluster:
 		jobManagerService.Spec.Type = corev1.ServiceTypeClusterIP
+		jobManagerService.Annotations = jobManagerSpec.ServiceAnnotations
 	case v1beta1.AccessScopeVPC:
 		jobManagerService.Spec.Type = corev1.ServiceTypeLoadBalancer
 		jobManagerService.Annotations =
@@ -301,8 +302,10 @@ func newJobManagerService(flinkCluster *v1beta1.FlinkCluster) *corev1.Service {
 			}
 	case v1beta1.AccessScopeExternal:
 		jobManagerService.Spec.Type = corev1.ServiceTypeLoadBalancer
+		jobManagerService.Annotations = jobManagerSpec.ServiceAnnotations
 	case v1beta1.AccessScopeNodePort:
 		jobManagerService.Spec.Type = corev1.ServiceTypeNodePort
+		jobManagerService.Annotations = jobManagerSpec.ServiceAnnotations
 	case v1beta1.AccessScopeHeadless:
 		// Headless services do not allocate any sort of VIP or LoadBalancer, and merely
 		// collect a set of Pod IPs that are assumed to be independently routable:

--- a/controllers/flinkcluster/flinkcluster_converter.go
+++ b/controllers/flinkcluster/flinkcluster_converter.go
@@ -272,7 +272,7 @@ func newJobManagerService(flinkCluster *v1beta1.FlinkCluster) *corev1.Service {
 	var jobManagerServiceName = getJobManagerServiceName(clusterName)
 	var podLabels = getComponentLabels(flinkCluster, "jobmanager")
 	podLabels = mergeLabels(podLabels, jobManagerSpec.PodLabels)
-	var serviceLabels = mergeLabels(podLabels, getRevisionHashLabels(&flinkCluster.Status.Revision))
+	var serviceLabels = mergeLabels(jobManagerSpec.ServiceLabels, getRevisionHashLabels(&flinkCluster.Status.Revision))
 	var serviceAnnotations = jobManagerSpec.ServiceAnnotations
 
 	var jobManagerService = &corev1.Service{

--- a/controllers/flinkcluster/flinkcluster_converter_test.go
+++ b/controllers/flinkcluster/flinkcluster_converter_test.go
@@ -485,9 +485,6 @@ func TestGetDesiredClusterState(t *testing.T) {
 			Name:      "flinkjobcluster-sample-jobmanager",
 			Namespace: "default",
 			Labels: map[string]string{
-				"app":             "flink",
-				"cluster":         "flinkjobcluster-sample",
-				"component":       "jobmanager",
 				RevisionNameLabel: "flinkjobcluster-sample-85dc8f749",
 			},
 			Annotations: map[string]string{

--- a/helm-chart/flink-operator/templates/flink-cluster-crd.yaml
+++ b/helm-chart/flink-operator/templates/flink-cluster-crd.yaml
@@ -1663,6 +1663,10 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                    ServiceLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
                     extraPorts:
                       items:
                         properties:

--- a/helm-chart/flink-operator/templates/flink-cluster-crd.yaml
+++ b/helm-chart/flink-operator/templates/flink-cluster-crd.yaml
@@ -1659,6 +1659,10 @@ spec:
                   properties:
                     accessScope:
                       type: string
+                    ServiceAnnotations:
+                      additionalProperties:
+                        type: string
+                      type: object
                     extraPorts:
                       items:
                         properties:


### PR DESCRIPTION
Issue ref: https://github.com/spotify/flink-on-k8s-operator/issues/319

Result of patch:

* Changes to example cluster:
```
   jobManager:
+    accessScope: External
+    ServiceAnnotations:
+      service.beta.kubernetes.io/aws-load-balancer-internal: "true"
```

* Describe output from service:
```
$ kubectl describe svc flink-illiatest-jobmanager -n flink-job
Name:                     flink-illiatest-jobmanager
Namespace:                flink-job
Labels:                   app=flink
                          cluster=flink-illiatest
                          component=jobmanager
                          flinkoperator.k8s.io/revision-name=flink-illiatest-67bd68c554
Annotations:              service.beta.kubernetes.io/aws-load-balancer-internal: true
```

Image I built to test feature: https://hub.docker.com/repository/docker/sudokamikaze/flinktests built on latest master HEAD + my changes