### PR TITLE
Move out the RBAC proxy image as templating value

### DIFF
--- a/helm-chart/flink-operator/templates/flink-operator.yaml
+++ b/helm-chart/flink-operator/templates/flink-operator.yaml
@@ -58,7 +58,8 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: {{ .Values.rbacProxyImage.name }}
+        imagePullPolicy: {{ .Values.rbacProxyImage.pullPolicy }}
         ports:
         - containerPort: 8443
           name: https
@@ -71,6 +72,7 @@ spec:
         command:
         - /flink-operator
         image: {{ .Values.operatorImage.name }}
+        imagePullPolicy: {{ .Values.operatorImage.pullPolicy }}
         ports:
         - containerPort: 9443
           name: webhook-server

--- a/helm-chart/flink-operator/values.yaml
+++ b/helm-chart/flink-operator/values.yaml
@@ -4,7 +4,7 @@ flinkOperatorNamespace:
 
 # Watch custom resources in the namespace, ignore other namespaces. If empty, all namespaces will be watched.
 watchNamespace:
-  name: "flink-job"
+  name: ""
 
 # The number of replicas of the operator Deployment
 replicas: 1
@@ -25,6 +25,11 @@ rbac:
 # The definition of the operator image
 operatorImage:
   name: ghcr.io/spotify/flink-operator:latest
+  pullPolicy: IfNotPresent
+
+# The definition of the kube-rbac-proxy image
+rbacProxyImage:
+  name: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
   pullPolicy: IfNotPresent
 
 # Defines security context for operator container


### PR DESCRIPTION
Hi there, 

thanks a lot for providing and keeping up to date this fork. I would like to contribute this small PR to: 
- incorporate `imagePullPolicy` for the operatorImage at flink-operator.yaml  (it was setup by never used)
- allow the possibility to specify RBAC proxy docker image as templating so that custom artifactory/mirrors can also be attached to it
- Revert back the watch namespace to be empty for default values

Best regards, 
Gezim