### PR TITLE
Add release helm charts workflow

### DIFF
--- a/.github/workflows/release-helm-charts.yaml
+++ b/.github/workflows/release-helm-charts.yaml
@@ -1,0 +1,33 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.7.2
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.2.1
+        with:
+          charts_dir: helm-chart
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Hi everyone, 

I do understand that the helm-chart release should also be official under the operator name/domain but sometimes it is really hard to keep sync/install it from sources when you also want to keep in sync with the latest changes of the chart or even to extreme install it e.g. on GKE via terraform -- as such you have to install it into some registry which is then able to be used are repo.

To really get rid of all those manual steps I did test this workflow with [one demo example](https://github.com/GezimSejdiu/helm-chart-releaser-demo) and it seems to work out-of the box thanks to https://github.com/helm/chart-releaser-action.

So instad of installing it from sources (I didnt' update the documentation yet, but I can also do it when this goes through so that we also adapt them with the change on how to use the chart(s)) we could just do: 
```console
helm repo add flink-operator https://spotify.github.io/flink-on-k8s-operator/
```
and then install it via: 
```console
helm install [RELEASE_NAME]  flink-operator/flink-operator --set operatorImage.name=[IMAGE_NAME]
```

In order to get this deployed we should also enable the:
> In your repo, go to Settings/Pages. Change the Source Branch to gh-pages.

as explained here: https://github.com/helm/chart-releaser-action#pre-requisites

What do you think about this? 
