### PR TITLE
Update beam example cluster yaml

### DIFF
--- a/examples/beam/with_job_server/beam_flink_cluster.yaml
+++ b/examples/beam/with_job_server/beam_flink_cluster.yaml
@@ -3,17 +3,11 @@ kind: FlinkCluster
 metadata:
   name: beam-flink-cluster
 spec:
+  flinkVersion: 1.8.1
   image:
     name: flink:1.8.1
-  jobManager:
-    resources:
-      limits:
-        memory: "1Gi"
   taskManager:
     replicas: 2
-    resources:
-      limits:
-        memory: "2Gi"
     sidecars:
       - name: beam-worker-pool
         image: apachebeam/python3.7_sdk:2.18.0

--- a/examples/beam/without_job_server/beam_flink_cluster.yaml
+++ b/examples/beam/without_job_server/beam_flink_cluster.yaml
@@ -3,17 +3,11 @@ kind: FlinkCluster
 metadata:
   name: beam-flink-cluster
 spec:
+  flinkVersion: 1.10.1
   image:
     name: flink:1.10.1
-  jobManager:
-    resources:
-      limits:
-        memory: "1Gi"
   taskManager:
     replicas: 2
-    resources:
-      limits:
-        memory: "2Gi"
     sidecars:
       - name: beam-worker-pool
         image: apache/beam_python3.7_sdk:2.22.0


### PR DESCRIPTION
Existing yaml files fails because of missing flinkVersion and resources cpu limit not defined.

Add required spec.flinkVersion
Remove resources so that default values will be used