### PR TITLE
reduce pvc list logging

### DIFF
--- a/controllers/flinkcluster/flinkcluster_observer.go
+++ b/controllers/flinkcluster/flinkcluster_observer.go
@@ -599,7 +599,7 @@ func (observer *ClusterStateObserver) observePersistentVolumeClaims(
 		}
 		log.Info("Observed persistent volume claim list", "state", "nil")
 	} else {
-		log.Info("Observed persistent volume claim list", "state", *observedClaims)
+		log.Info("Observed persistent volume claim list", "state", len(observedClaims.Items))
 	}
 
 	return nil


### PR DESCRIPTION
We are running a job with 600 replicas. Unlike other logs, this one grows with replica count. It started breaking our GCP structured logging. Can we log count instead of all items?