### PR TITLE
fixes #392, select "main" container for logs

### DIFF
--- a/internal/util/kube.go
+++ b/internal/util/kube.go
@@ -17,7 +17,7 @@ func GetPodLogs(clientset *kubernetes.Clientset, pod *corev1.Pod) (string, error
 	}
 	pods := clientset.CoreV1().Pods(pod.Namespace)
 
-	req := pods.GetLogs(pod.Name, &corev1.PodLogOptions{})
+	req := pods.GetLogs(pod.Name, &corev1.PodLogOptions{Container: "main"})
 	podLogs, err := req.Stream(context.TODO())
 	if err != nil {
 		return "", fmt.Errorf("failed to get logs for pod %s: %v", pod.Name, err)


### PR DESCRIPTION
Unclear why the selector was dropped in this commit: https://github.com/spotify/flink-on-k8s-operator/commit/ffd9ec7cdad8370662847223b4cc4b2b91154433