### PR TITLE
Add Headless service for TaskManagers

### DIFF
--- a/controllers/flinkcluster/flinkcluster_controller.go
+++ b/controllers/flinkcluster/flinkcluster_controller.go
@@ -191,6 +191,11 @@ func (handler *FlinkClusterHandler) reconcile(ctx context.Context,
 	} else {
 		log.Info("Desired state", "PodDisruptionBudget", "nil")
 	}
+	if desired.TmService != nil {
+		log.Info("Desired state", "TaskManager Service", *desired.TmService)
+	} else {
+		log.Info("Desired state", "TaskManager Service", "nil")
+	}
 	if desired.JmStatefulSet != nil {
 		log.Info("Desired state", "JobManager StatefulSet", *desired.JmStatefulSet)
 	} else {

--- a/controllers/flinkcluster/flinkcluster_util.go
+++ b/controllers/flinkcluster/flinkcluster_util.go
@@ -384,8 +384,9 @@ func isUpdatedAll(observed ObservedClusterState) bool {
 	components := []runtime.Object{
 		observed.configMap,
 		observed.podDisruptionBudget,
-		observed.jmStatefulSet,
 		observed.tmStatefulSet,
+		observed.tmService,
+		observed.jmStatefulSet,
 		observed.jmService,
 		observed.jmIngress,
 		observed.flinkJobSubmitter.job,
@@ -401,8 +402,9 @@ func isClusterUpdateToDate(observed *ObservedClusterState) bool {
 	components := []runtime.Object{
 		observed.configMap,
 		observed.podDisruptionBudget,
-		observed.jmStatefulSet,
 		observed.tmStatefulSet,
+		observed.tmService,
+		observed.jmStatefulSet,
 		observed.jmService,
 	}
 	return areComponentsUpdated(components, observed.cluster)

--- a/controllers/flinkcluster/flinkcluster_util_test.go
+++ b/controllers/flinkcluster/flinkcluster_util_test.go
@@ -269,6 +269,7 @@ func TestGetUpdateState(t *testing.T) {
 		podDisruptionBudget: &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{RevisionNameLabel: "cluster-85dc8f749"}}},
 		jmStatefulSet:       &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{RevisionNameLabel: "cluster-85dc8f749"}}},
 		tmStatefulSet:       &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{RevisionNameLabel: "cluster-85dc8f749"}}},
+		tmService:           &corev1.Service{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{RevisionNameLabel: "cluster-85dc8f749"}}},
 		jmService:           &corev1.Service{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{RevisionNameLabel: "cluster-85dc8f749"}}},
 	}
 	var state = getUpdateState(&observed)
@@ -305,6 +306,7 @@ func TestGetUpdateState(t *testing.T) {
 		jmStatefulSet:       &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{RevisionNameLabel: "cluster-aa5e3a87z"}}},
 		tmStatefulSet:       &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{RevisionNameLabel: "cluster-aa5e3a87z"}}},
 		jmService:           &corev1.Service{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{RevisionNameLabel: "cluster-aa5e3a87z"}}},
+		tmService:           &corev1.Service{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{RevisionNameLabel: "cluster-aa5e3a87z"}}},
 		jmIngress:           &networkingv1.Ingress{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{RevisionNameLabel: "cluster-aa5e3a87z"}}},
 	}
 	state = getUpdateState(&observed)

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -27,6 +27,7 @@ type DesiredClusterState struct {
 	JmService           *corev1.Service
 	JmIngress           *networkingv1.Ingress
 	TmStatefulSet       *appsv1.StatefulSet
+	TmService           *corev1.Service
 	ConfigMap           *corev1.ConfigMap
 	Job                 *batchv1.Job
 	PodDisruptionBudget *policyv1.PodDisruptionBudget


### PR DESCRIPTION
To enable `jobmanager.retrieve-taskmanager-hostname: "true"` and allow faster recovery of lost TMs,  a headless service has to be created for the pods of the TM statefulset. 

This is not created automatically, when the statefulset is created: See more at https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#stable-network-id