### PR TITLE
DeploymentType should be StatefulSet if defaulting webhook fails

### DIFF
--- a/controllers/flinkcluster/flinkcluster_converter.go
+++ b/controllers/flinkcluster/flinkcluster_converter.go
@@ -98,7 +98,8 @@ func getDesiredClusterState(observed *ObservedClusterState) *model.DesiredCluste
 		state.JmStatefulSet = newJobManagerStatefulSet(cluster)
 	}
 
-	if cluster.Spec.TaskManager.DeploymentType == v1beta1.DeploymentTypeStatefulSet {
+	deploymentType := cluster.Spec.TaskManager.DeploymentType
+	if deploymentType == v1beta1.DeploymentTypeStatefulSet || deploymentType == "" {
 		if !shouldCleanup(cluster, "TaskManagerStatefulSet") {
 			state.TmStatefulSet = newTaskManagerStatefulSet(cluster)
 		}


### PR DESCRIPTION
If the defaulting webhook fails for some reason, this check will ensure that the desired state uses 
`deploymentType: StatefulSet`

cc: @jto 