### PR TITLE
Forward submitter exitcode to FlinkCluster status

### DIFF
--- a/apis/flinkcluster/v1beta1/flinkcluster_types.go
+++ b/apis/flinkcluster/v1beta1/flinkcluster_types.go
@@ -52,17 +52,18 @@ type JobMode string
 
 // JobState defines states for a Flink job deployment.
 const (
-	JobStatePending      = "Pending"
-	JobStateUpdating     = "Updating"
-	JobStateRestarting   = "Restarting"
-	JobStateDeploying    = "Deploying"
-	JobStateDeployFailed = "DeployFailed"
-	JobStateRunning      = "Running"
-	JobStateSucceeded    = "Succeeded"
-	JobStateCancelled    = "Cancelled"
-	JobStateFailed       = "Failed"
-	JobStateLost         = "Lost"
-	JobStateUnknown      = "Unknown"
+	JobStatePending         = "Pending"
+	JobStateUpdating        = "Updating"
+	JobStateRestarting      = "Restarting"
+	JobStateDeploying       = "Deploying"
+	JobStateDeployFailed    = "DeployFailed"
+	JobStateSubmitterFailed = "SubmitterFailed"
+	JobStateRunning         = "Running"
+	JobStateSucceeded       = "Succeeded"
+	JobStateCancelled       = "Cancelled"
+	JobStateFailed          = "Failed"
+	JobStateLost            = "Lost"
+	JobStateUnknown         = "Unknown"
 )
 
 // AccessScope defines the access scope of JobManager service.

--- a/apis/flinkcluster/v1beta1/flinkcluster_types.go
+++ b/apis/flinkcluster/v1beta1/flinkcluster_types.go
@@ -734,6 +734,9 @@ type JobStatus struct {
 	// The name of the Kubernetes job resource.
 	SubmitterName string `json:"submitterName,omitempty"`
 
+	// Exit code of the JubSubmitter job resource.
+	SubmitterExitCode int32 `json:"submitterExitCode,omitempty"`
+
 	// The state of the Flink job deployment.
 	State string `json:"state"`
 

--- a/apis/flinkcluster/v1beta1/flinkcluster_types_util.go
+++ b/apis/flinkcluster/v1beta1/flinkcluster_types_util.go
@@ -22,7 +22,8 @@ func (j *JobStatus) IsFailed() bool {
 	return j != nil &&
 		(j.State == JobStateFailed ||
 			j.State == JobStateLost ||
-			j.State == JobStateDeployFailed)
+			j.State == JobStateDeployFailed ||
+			j.State == JobStateSubmitterFailed)
 }
 
 func (j *JobStatus) IsStopped() bool {

--- a/apis/flinkcluster/v1beta1/zz_generated.deepcopy.go
+++ b/apis/flinkcluster/v1beta1/zz_generated.deepcopy.go
@@ -574,13 +574,6 @@ func (in *JobManagerSpec) DeepCopyInto(out *JobManagerSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.HostAliases != nil {
-		in, out := &in.HostAliases, &out.HostAliases
-		*out = make([]v1.HostAlias, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
-	}
 	if in.Sidecars != nil {
 		in, out := &in.Sidecars, &out.Sidecars
 		*out = make([]v1.Container, len(*in))
@@ -616,6 +609,13 @@ func (in *JobManagerSpec) DeepCopyInto(out *JobManagerSpec) {
 		in, out := &in.ReadinessProbe, &out.ReadinessProbe
 		*out = new(v1.Probe)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.HostAliases != nil {
+		in, out := &in.HostAliases, &out.HostAliases
+		*out = make([]v1.HostAlias, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 }
 
@@ -742,13 +742,6 @@ func (in *JobSpec) DeepCopyInto(out *JobSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.HostAliases != nil {
-		in, out := &in.HostAliases, &out.HostAliases
-		*out = make([]v1.HostAlias, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
-	}
 	if in.RestartPolicy != nil {
 		in, out := &in.RestartPolicy, &out.RestartPolicy
 		*out = new(JobRestartPolicy)
@@ -783,6 +776,13 @@ func (in *JobSpec) DeepCopyInto(out *JobSpec) {
 		in, out := &in.SecurityContext, &out.SecurityContext
 		*out = new(v1.PodSecurityContext)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.HostAliases != nil {
+		in, out := &in.HostAliases, &out.HostAliases
+		*out = make([]v1.HostAlias, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	if in.Mode != nil {
 		in, out := &in.Mode, &out.Mode
@@ -973,13 +973,6 @@ func (in *TaskManagerSpec) DeepCopyInto(out *TaskManagerSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.HostAliases != nil {
-		in, out := &in.HostAliases, &out.HostAliases
-		*out = make([]v1.HostAlias, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
-	}
 	if in.Sidecars != nil {
 		in, out := &in.Sidecars, &out.Sidecars
 		*out = make([]v1.Container, len(*in))
@@ -1015,6 +1008,13 @@ func (in *TaskManagerSpec) DeepCopyInto(out *TaskManagerSpec) {
 		in, out := &in.ReadinessProbe, &out.ReadinessProbe
 		*out = new(v1.Probe)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.HostAliases != nil {
+		in, out := &in.HostAliases, &out.HostAliases
+		*out = make([]v1.HostAlias, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 }
 

--- a/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
+++ b/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
@@ -203,6 +203,17 @@ spec:
                       type: object
                     fromSavepoint:
                       type: string
+                    hostAliases:
+                      items:
+                        properties:
+                          hostnames:
+                            items:
+                              type: string
+                            type: array
+                          ip:
+                            type: string
+                        type: object
+                      type: array
                     initContainers:
                       items:
                         properties:
@@ -897,17 +908,6 @@ spec:
                             type: integer
                           value:
                             type: string
-                        type: object
-                      type: array
-                    hostAliases:
-                      items:
-                        properties:
-                          ip:
-                            type: string
-                          hostnames:
-                            items:
-                              type: string
-                            type: array
                         type: object
                       type: array
                     volumeMounts:
@@ -1660,6 +1660,17 @@ spec:
                             type: string
                         required:
                           - containerPort
+                        type: object
+                      type: array
+                    hostAliases:
+                      items:
+                        properties:
+                          hostnames:
+                            items:
+                              type: string
+                            type: array
+                          ip:
+                            type: string
                         type: object
                       type: array
                     ingress:
@@ -3066,17 +3077,6 @@ spec:
                             type: string
                         type: object
                       type: array
-                    hostAliases:
-                      items:
-                        properties:
-                          ip:
-                            type: string
-                          hostnames:
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      type: array
                     volumeClaimTemplates:
                       items:
                         properties:
@@ -3974,6 +3974,17 @@ spec:
                             type: string
                         required:
                           - containerPort
+                        type: object
+                      type: array
+                    hostAliases:
+                      items:
+                        properties:
+                          hostnames:
+                            items:
+                              type: string
+                            type: array
+                          ip:
+                            type: string
                         type: object
                       type: array
                     initContainers:
@@ -5364,17 +5375,6 @@ spec:
                             type: string
                         type: object
                       type: array
-                    hostAliases:
-                      items:
-                        properties:
-                          ip:
-                            type: string
-                          hostnames:
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      type: array
                     volumeClaimTemplates:
                       items:
                         properties:
@@ -6290,6 +6290,9 @@ spec:
                           type: string
                         state:
                           type: string
+                        submitterExitCode:
+                          format: int32
+                          type: integer
                         submitterName:
                           type: string
                       required:

--- a/controllers/flinkcluster/flinkcluster_converter.go
+++ b/controllers/flinkcluster/flinkcluster_converter.go
@@ -1065,7 +1065,7 @@ func shouldCleanup(cluster *v1beta1.FlinkCluster, component string) bool {
 	switch jobStatus.State {
 	case v1beta1.JobStateSucceeded:
 		action = cluster.Spec.Job.CleanupPolicy.AfterJobSucceeds
-	case v1beta1.JobStateFailed, v1beta1.JobStateLost, v1beta1.JobStateDeployFailed:
+	case v1beta1.JobStateFailed, v1beta1.JobStateLost, v1beta1.JobStateDeployFailed, v1beta1.JobStateSubmitterFailed:
 		action = cluster.Spec.Job.CleanupPolicy.AfterJobFails
 	case v1beta1.JobStateCancelled:
 		action = cluster.Spec.Job.CleanupPolicy.AfterJobCancelled

--- a/controllers/flinkcluster/flinkcluster_observer.go
+++ b/controllers/flinkcluster/flinkcluster_observer.go
@@ -440,6 +440,7 @@ func (observer *ClusterStateObserver) observeFlinkJobStatus(observed *ObservedCl
 			flinkJob.exceptions = flinkJobExceptions
 		}
 	}
+
 }
 
 func (observer *ClusterStateObserver) observeSavepoint(cluster *v1beta1.FlinkCluster, savepoint *Savepoint) error {

--- a/controllers/flinkcluster/flinkcluster_submit_job_script.go
+++ b/controllers/flinkcluster/flinkcluster_submit_job_script.go
@@ -153,7 +153,7 @@ function submit_job() {
     # check the job's exit code
     if [ $job_exit_code -ne 0 ]; then
         write_term_log_msg "Job failed with a non-zero exit code: ${job_exit_code}" "submit_log"
-        return 1
+        return $job_exit_code
     fi        
 
     # On success, write log
@@ -168,9 +168,7 @@ function main() {
     fi
 
     echo -e "\n---------- Submitting job ----------"
-    if ! submit_job "$@"; then
-        exit 2
-    fi
+    submit_job "$@"
 }
 
 main "$@"

--- a/controllers/flinkcluster/flinkcluster_submit_job_script.go
+++ b/controllers/flinkcluster/flinkcluster_submit_job_script.go
@@ -168,7 +168,11 @@ function main() {
     fi
 
     echo -e "\n---------- Submitting job ----------"
+    set +e
     submit_job "$@"
+    submit_job_result=$?
+    set -e
+    exit $submit_job_result
 }
 
 main "$@"

--- a/controllers/flinkcluster/flinkcluster_updater.go
+++ b/controllers/flinkcluster/flinkcluster_updater.go
@@ -573,7 +573,8 @@ func (updater *ClusterStatusUpdater) deriveJobSubmitterExitCodeAndReason(pod *co
 		if containerStatus.Name == jobSubmitterPodMainContainerName && containerStatus.State.Terminated != nil {
 			exitCode := containerStatus.State.Terminated.ExitCode
 			reason := containerStatus.State.Terminated.Reason
-			return exitCode, fmt.Sprintf("[Exit code: %d] Reason: %s", exitCode, reason)
+			message := containerStatus.State.Terminated.Message
+			return exitCode, fmt.Sprintf("[Exit code: %d] Reason: %s, Message: %s", exitCode, reason, message)
 		}
 	}
 	return -1, ""

--- a/docs/crd.md
+++ b/docs/crd.md
@@ -367,6 +367,7 @@ _Appears in:_
 | `id` _string_ | The ID of the Flink job. |
 | `name` _string_ | The Name of the Flink job. |
 | `submitterName` _string_ | The name of the Kubernetes job resource. |
+| `submitterExitCode` _integer_ | Exit code of the main container in JobSubmitter pod. (-1 means the main container is still running) |
 | `state` _string_ | The state of the Flink job deployment. |
 | `fromSavepoint` _string_ | The actual savepoint from which this job started. In case of restart, it might be different from the savepoint in the job spec. |
 | `savepointGeneration` _integer_ | The generation of the savepoint in `savepointsDir` taken by the operator. The value starts from 0 when there is no savepoint and increases by 1 for each successful savepoint. |


### PR DESCRIPTION
Fixes #424 

- Job submitter script swallows the job exit code. It should just forward it.
- The exit code of the submitter should be made available in the FlinkCluster Status
- JobState should be marked as Failed if the submitter exit code is not zero.[ This commit](https://github.com/spotify/flink-on-k8s-operator/pull/425/commits/4eb671b49500a143092d088acead12b6e53772b1) tries to make this happen. Do we need this? 🤔 