### PR TITLE
Wait for submitter to exit before tearing down

### DIFF
--- a/controllers/flinkcluster/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler.go
@@ -810,6 +810,10 @@ func (reconciler *ClusterReconciler) reconcileJob() (ctrl.Result, error) {
 		}
 
 		if job.IsStopped() && observedSubmitter != nil {
+			if observed.cluster.Status.Components.Job.SubmitterExitCode == -1 {
+				log.Info("Job submitter has not finished yet")
+				return requeueResult, fmt.Errorf("wait for jobSubmitter to exit")
+			}
 			if err := reconciler.deleteJob(observedSubmitter); err != nil {
 				return requeueResult, err
 			}


### PR DESCRIPTION
There can be things that need to execute in the `main` after the flink job. Currently, the cluster can be torn down before that happens (it is a race condition). 