### PR TITLE
Noop on attempt to cancel non-running job

### DIFF
--- a/apis/flinkcluster/v1beta1/flinkcluster_validate.go
+++ b/apis/flinkcluster/v1beta1/flinkcluster_validate.go
@@ -149,7 +149,8 @@ func (v *Validator) checkControlAnnotations(old *FlinkCluster, new *FlinkCluster
 			if old.Spec.Job == nil {
 				return fmt.Errorf(SessionClusterWarnMsg, ControlNameJobCancel, ControlAnnotation)
 			} else if job == nil || job.IsTerminated(old.Spec.Job) {
-				return fmt.Errorf(InvalidJobStateForJobCancelMsg, ControlAnnotation)
+				log.Info("Attempted cancelling of non-existing or already terminated job", "job", job)
+				return nil
 			}
 		case ControlNameSavepoint:
 			var job = old.Status.Components.Job

--- a/apis/flinkcluster/v1beta1/flinkcluster_validate.go
+++ b/apis/flinkcluster/v1beta1/flinkcluster_validate.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-version"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	corev1 "k8s.io/api/core/v1"
@@ -149,8 +150,7 @@ func (v *Validator) checkControlAnnotations(old *FlinkCluster, new *FlinkCluster
 			if old.Spec.Job == nil {
 				return fmt.Errorf(SessionClusterWarnMsg, ControlNameJobCancel, ControlAnnotation)
 			} else if job == nil || job.IsTerminated(old.Spec.Job) {
-				log.Info("Attempted cancelling of non-existing or already terminated job", "job", job)
-				return nil
+				return errors.NewResourceExpired(fmt.Sprintf(InvalidJobStateForJobCancelMsg, ControlAnnotation))
 			}
 		case ControlNameSavepoint:
 			var job = old.Status.Components.Job


### PR DESCRIPTION
In has finished or was already cancelled, the validation webhook rejects the cancellation attempt. This leads to any external system (ie. Flyte) attempting to continuously retrying the cancellation to reconcile its state.