### PR TITLE
use same pvc labels for tm deployment mode as statefulSet mode

### DIFF
--- a/controllers/flinkcluster/flinkcluster_converter.go
+++ b/controllers/flinkcluster/flinkcluster_converter.go
@@ -543,7 +543,7 @@ func newTaskManagerStatefulSet(flinkCluster *v1beta1.FlinkCluster) *appsv1.State
 	}
 }
 
-func getEphemeralVolumesFromTaskManagerSpec(flinkCluster *v1beta1.FlinkCluster) []corev1.Volume {
+func getEphemeralVolumesFromTaskManagerSpec(flinkCluster *v1beta1.FlinkCluster, labels map[string]string) []corev1.Volume {
 	var ephemeralVolumes []corev1.Volume
 	var volumeClaimsInSpec = flinkCluster.Spec.TaskManager.VolumeClaimTemplates
 	for _, volume := range volumeClaimsInSpec {
@@ -553,6 +553,9 @@ func getEphemeralVolumesFromTaskManagerSpec(flinkCluster *v1beta1.FlinkCluster) 
 			VolumeSource: corev1.VolumeSource{
 				Ephemeral: &corev1.EphemeralVolumeSource{
 					VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: labels,
+						},
 						Spec: volume.Spec,
 					},
 				},
@@ -572,7 +575,7 @@ func newTaskManagerDeployment(flinkCluster *v1beta1.FlinkCluster) *appsv1.Deploy
 
 	mainContainer := newTaskManagerContainer(flinkCluster)
 	podSpec := newTaskManagerPodSpec(mainContainer, flinkCluster)
-	podSpec.Volumes = append(podSpec.Volumes, getEphemeralVolumesFromTaskManagerSpec(flinkCluster)...)
+	podSpec.Volumes = append(podSpec.Volumes, getEphemeralVolumesFromTaskManagerSpec(flinkCluster, podLabels)...)
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/flinkcluster/flinkcluster_converter_test.go
+++ b/controllers/flinkcluster/flinkcluster_converter_test.go
@@ -1223,6 +1223,13 @@ func TestTmDeploymentTypeDeployment(t *testing.T) {
 							VolumeSource: corev1.VolumeSource{
 								Ephemeral: &corev1.EphemeralVolumeSource{
 									VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
+										ObjectMeta: metav1.ObjectMeta{
+											Labels: map[string]string{
+												"app":       "flink",
+												"cluster":   "flinkjobcluster-sample",
+												"component": "taskmanager",
+											},
+										},
 										Spec: corev1.PersistentVolumeClaimSpec{
 											AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 											Resources: corev1.ResourceRequirements{


### PR DESCRIPTION
This commit adds labels to ephemeral volumeClaimTemplate, so same labels are used at both statefulSet or deployment pvcs.