### PR TITLE
fix rbac permissions

### DIFF
--- a/helm-chart/flink-operator/templates/rbac.yaml
+++ b/helm-chart/flink-operator/templates/rbac.yaml
@@ -210,6 +210,18 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
       - networking.k8s.io
     resources:
       - ingresses


### PR DESCRIPTION
When `Job` trying to generate sertificate used [this](https://github.com/spotify/flink-on-k8s-operator/blob/master/helm-chart/flink-operator/templates/generate-cert.yaml#L51) command it fails due `ServiceAccount` hasn't enought permissions. These permissions was removed in [PR](https://github.com/spotify/flink-on-k8s-operator/pull/370/files#diff-f5d59742bca6a6fa846c9e3cbce825b51b7ce9c98c91852b8c224f941374e6ffL135)