### PR TITLE
job-cancel control should tear down the cluster within a reasonable amount of time

### DIFF
--- a/apis/flinkcluster/v1beta1/flinkcluster_default.go
+++ b/apis/flinkcluster/v1beta1/flinkcluster_default.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1beta1
 
 import (
+	"time"
+
 	"github.com/hashicorp/go-version"
 	"github.com/imdario/mergo"
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +29,7 @@ import (
 const (
 	DefaultJobManagerReplicas  = 1
 	DefaultTaskManagerReplicas = 3
+	ForceTearDownAfter         = time.Second * 10
 )
 
 var (

--- a/controllers/flinkcluster/flinkcluster_updater.go
+++ b/controllers/flinkcluster/flinkcluster_updater.go
@@ -614,6 +614,11 @@ func (updater *ClusterStatusUpdater) deriveJobStatus() *v1beta1.JobStatus {
 		if oldJob.SubmitterExitCode != exitCode && isNonZeroExitCode(exitCode) {
 			newJob.FailureReasons = append(newJob.FailureReasons, reason)
 		}
+	} else if observedSubmitter.job == nil || observed.flinkJobSubmitter.pod == nil {
+		// Submitter is nil, so the submitter exit code shouldn't be "running"
+		if oldJob != nil && oldJob.SubmitterExitCode == -1 {
+			newJob.SubmitterExitCode = 0
+		}
 	}
 
 	var newJobState string
@@ -984,7 +989,7 @@ func deriveControlStatus(
 	var c *v1beta1.FlinkClusterControlStatus
 
 	// New control status
-	if controlRequest != "" {
+	if controlStatusChanged(cluster, controlRequest) {
 		c = getControlStatus(controlRequest, v1beta1.ControlStateRequested)
 		return c
 	}


### PR DESCRIPTION
Fixes #434 
+

- control status requested should only be updated at the first reconcile (and not every reconcile). To keep track of when the control was actually requested.
- Reasonable amount of time can then be computed from when the control was requested.