### PR TITLE
Fix job submitter status nil pointer access

### DIFF
--- a/controllers/flinkcluster/flinkcluster_observer.go
+++ b/controllers/flinkcluster/flinkcluster_observer.go
@@ -112,10 +112,10 @@ func (s *FlinkJobSubmitter) getState() JobSubmitState {
 		return JobDeployStateSucceeded
 	// Job ID not found cases:
 	// Failed and job ID not found.
-	case s.job.Status.Failed > 0:
+	case s.job != nil && s.job.Status.Failed > 0:
 		return JobDeployStateFailed
 	// Ongoing job submission.
-	case s.job.Status.Succeeded == 0 && s.job.Status.Failed == 0:
+	case s.job != nil && s.job.Status.Succeeded == 0 && s.job.Status.Failed == 0:
 		fallthrough
 	// Finished, but failed to extract log.
 	case s.log == nil:


### PR DESCRIPTION
Fixes issue happening with certain streaming clusters:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x468 pc=0x13e1cc5]

goroutine 551 [running]:
github.com/spotify/flink-on-k8s-operator/controllers/flinkcluster.(*FlinkJobSubmitter).getState(...)
	/workspace/controllers/flinkcluster/flinkcluster_observer.go:115
github.com/spotify/flink-on-k8s-operator/controllers/flinkcluster.(*ClusterStatusUpdater).deriveJobStatus(0xc053113898)
	/workspace/controllers/flinkcluster/flinkcluster_updater.go:664 +0x8c5
...
```