### PR TITLE
send an event when the cluster is deleted

### DIFF
--- a/controllers/flinkcluster/flinkcluster_controller.go
+++ b/controllers/flinkcluster/flinkcluster_controller.go
@@ -139,6 +139,7 @@ func (handler *FlinkClusterHandler) reconcile(ctx context.Context,
 		request:      request,
 		context:      context,
 		log:          log,
+		recorder:     handler.recorder,
 		history:      history,
 	}
 	err = observer.observe(observed)


### PR DESCRIPTION
With this commit, an event will be send when a FLinkCluster is detected to be deleted.