### PR TITLE
Keep revision compat with RestartPolicy omitempty

### DIFF
--- a/apis/flinkcluster/v1beta1/flinkcluster_types.go
+++ b/apis/flinkcluster/v1beta1/flinkcluster_types.go
@@ -556,8 +556,7 @@ type JobSpec struct {
 	// the job will stay in failed state. This option is usually used together
 	// with `autoSavepointSeconds` and `savepointsDir`.
 	// +kubebuilder:default:=Never
-	// TODO: this field should be omitempty but since it affects job revision we need to defer it to v1beta2
-	RestartPolicy *JobRestartPolicy `json:"restartPolicy"`
+	RestartPolicy *JobRestartPolicy `json:"restartPolicy,omitempty"`
 
 	// The action to take after job finishes.
 	// +kubebuilder:default:={afterJobSucceeds:DeleteCluster, afterJobFails:KeepCluster, afterJobCancelled:DeleteCluster}


### PR DESCRIPTION
There's no easy way to keep back/forward compat even with a new CRD version like v1beta2. Decided to keep internal serde the same till we add new CRD's.