### PR TITLE
Make PodDisruptionBudget optional

### DIFF
--- a/apis/flinkcluster/v1beta1/flinkcluster_types.go
+++ b/apis/flinkcluster/v1beta1/flinkcluster_types.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -632,6 +633,10 @@ type FlinkClusterSpec struct {
 	// _(Optional)_ BatchScheduler specifies the batch scheduler for JobManager, TaskManager.
 	// If empty, no batch scheduling is enabled.
 	BatchScheduler *BatchSchedulerSpec `json:"batchScheduler,omitempty"`
+
+	// _(Optional)_ Defines the PodDisruptionBudget for JobManager and TaskManager.
+	// If empty, no PodDisruptionBudget is created.
+	PodDisruptionBudget *policyv1.PodDisruptionBudgetSpec `json:"podDisruptionBudget,omitempty"`
 
 	// _(Optional)_ Flink JobManager spec.
 	// +kubebuilder:default:={replicas:1}

--- a/apis/flinkcluster/v1beta1/zz_generated.deepcopy.go
+++ b/apis/flinkcluster/v1beta1/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1beta1
 
 import (
 	"k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -211,6 +212,11 @@ func (in *FlinkClusterSpec) DeepCopyInto(out *FlinkClusterSpec) {
 		in, out := &in.BatchScheduler, &out.BatchScheduler
 		*out = new(BatchSchedulerSpec)
 		**out = **in
+	}
+	if in.PodDisruptionBudget != nil {
+		in, out := &in.PodDisruptionBudget, &out.PodDisruptionBudget
+		*out = new(policyv1.PodDisruptionBudgetSpec)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.JobManager != nil {
 		in, out := &in.JobManager, &out.JobManager

--- a/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
+++ b/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
@@ -4134,6 +4134,42 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
+                podDisruptionBudget:
+                  properties:
+                    maxUnavailable:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      x-kubernetes-int-or-string: true
+                    minAvailable:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      x-kubernetes-int-or-string: true
+                    selector:
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                  type: object
                 recreateOnUpdate:
                   default: true
                   type: boolean


### PR DESCRIPTION
This is a breaking change as the PDB will no longer be added by default.

If you rely on PDB make sure you define it in the CRD.

Fixes #487 