### PR TITLE
Follow-up to #610: don't skip validation if cancel request is used

### DIFF
--- a/apis/flinkcluster/v1beta1/flinkcluster_validate.go
+++ b/apis/flinkcluster/v1beta1/flinkcluster_validate.go
@@ -97,12 +97,9 @@ func (v *Validator) ValidateUpdate(old *FlinkCluster, new *FlinkCluster) error {
 		return nil
 	}
 
-	cancelRequested, err := v.checkCancelRequested(old, new)
+	_, err = v.checkCancelRequested(old, new)
 	if err != nil {
 		return err
-	}
-	if cancelRequested {
-		return nil
 	}
 
 	savepointGenUpdated, err := v.checkSavepointGeneration(old, new)


### PR DESCRIPTION
Follow up to #610. This PR is addressing deprecated spec prop to request job cancellation.