### PR TITLE
fix when job succeeds but submitter fails

### DIFF
--- a/controllers/flinkcluster/flinkcluster_observer.go
+++ b/controllers/flinkcluster/flinkcluster_observer.go
@@ -277,10 +277,11 @@ func (observer *ClusterStateObserver) observeJob(
 	}
 
 	var submitterLog *SubmitterLog
-	// Extract submission result only when it is in deployment progress.
+	// Extract submission result only when it is in deployment progress or the submitter pod failed.
 	// It is not necessary to get the log stream from the submitter pod always.
 	var jobDeployInProgress = recordedJob != nil && recordedJob.State == v1beta1.JobStateDeploying
-	if jobPod != nil && jobDeployInProgress {
+	var jobPodFailed = jobPod != nil && jobPod.Status.Phase == corev1.PodFailed
+	if jobPod != nil && (jobDeployInProgress || jobPodFailed) {
 		var err error
 		submitterLog, err = getFlinkJobSubmitLog(observer.k8sClientset, jobPod)
 		if err != nil {


### PR DESCRIPTION
Currently, when the job succeeds but the submitter fails, it is reported as Succeeded. In some cases, it is also reported that the cluster is torn down before submitter finishes.

This commit:
- Wait until the submitter finishes before marking a job as succeeded
- If the submitter fails, its log is added as failure reason.