### PR TITLE
Do not reset Flink job-ID

### DIFF
--- a/controllers/flinkcluster/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler.go
@@ -901,7 +901,7 @@ func (reconciler *ClusterReconciler) updateJobDeployStatus(ctx context.Context) 
 	var newJob = clusterClone.Status.Components.Job
 
 	// Reset running job information.
-	newJob.ID = ""
+	// newJob.ID = ""
 	newJob.StartTime = ""
 	newJob.CompletionTime = nil
 

--- a/controllers/flinkcluster/flinkcluster_updater.go
+++ b/controllers/flinkcluster/flinkcluster_updater.go
@@ -22,9 +22,10 @@ package flinkcluster
 import (
 	"encoding/json"
 	"fmt"
-	batchv1 "k8s.io/api/batch/v1"
 	"reflect"
 	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
 
 	"golang.org/x/net/context"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -667,8 +668,12 @@ func (updater *ClusterStatusUpdater) deriveJobStatus(ctx context.Context) *v1bet
 		newJobState = v1beta1.JobStateDeploying
 	// Derive the job state from the observed Flink job, if it exists.
 	case observedFlinkJob != nil:
-		newJob.ID = observedFlinkJob.Id
-		newJob.Name = observedFlinkJob.Name
+		if observedFlinkJob.Id != "" {
+			newJob.ID = observedFlinkJob.Id
+		}
+		if observedFlinkJob.Name != "" {
+			newJob.Name = observedFlinkJob.Name
+		}
 		tmpState := getFlinkJobDeploymentState(observedFlinkJob.State)
 		if observedSubmitter.job == nil || tmpState != v1beta1.JobStateSucceeded {
 			newJobState = tmpState

--- a/controllers/flinkcluster/flinkcluster_util.go
+++ b/controllers/flinkcluster/flinkcluster_util.go
@@ -593,6 +593,10 @@ func wasJobCancelRequested(controlStatus *v1beta1.FlinkClusterControlStatus) boo
 }
 
 func GenJobId(cluster *v1beta1.FlinkCluster) (string, error) {
+	if cluster != nil && cluster.Status.Components.Job != nil && cluster.Status.Components.Job.ID != "" {
+		return cluster.Status.Components.Job.ID, nil
+	}
+
 	if cluster == nil || len(cluster.Status.Revision.NextRevision) == 0 {
 		return "", fmt.Errorf("error generating job id: cluster or next revision is nil")
 	}


### PR DESCRIPTION
Fixes https://github.com/spotify/flink-on-k8s-operator/issues/711
Flink jobId should not be reset on submitter restart.
A new Flink Job ID on each restart can cause multiple jobs to be submitted after a JobManager restart.

Steps to reproduce:
- Start a job with Application mode and HighAvailability turned on
- rescale the FlinkCluster `kubectl rescale FlinkCluster <fc> --replicas=2`
- Delete jobManager pod
- Multiple jobs can be seen in the jobManager console upon job manager restart.
