### PR TITLE
if submitter fails, kill the job

### DIFF
--- a/controllers/flinkcluster/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler.go
@@ -501,6 +501,12 @@ func (reconciler *ClusterReconciler) reconcileJob(ctx context.Context) (ctrl.Res
 			return requeueResult, nil
 		}
 
+		if observedSubmitter != nil && observed.cluster.Status.Components.Job.SubmitterExitCode != -1 {
+			log.Info("Job submitter failed. No need to wait for the job to finish. Killing it.")
+			err = reconciler.cancelJob(ctx)
+			return requeueResult, err
+		}
+
 		// Suspend or stop job to proceed update.
 		if recorded.Revision.IsUpdateTriggered() && isJobUpdate(observed.revisions, observed.cluster) {
 			log.Info("Preparing job update")

--- a/controllers/flinkcluster/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler.go
@@ -501,12 +501,6 @@ func (reconciler *ClusterReconciler) reconcileJob(ctx context.Context) (ctrl.Res
 			return requeueResult, nil
 		}
 
-		if observedSubmitter != nil && observed.cluster.Status.Components.Job.SubmitterExitCode != -1 {
-			log.Info("Job submitter failed. No need to wait for the job to finish. Killing it.")
-			err = reconciler.cancelJob(ctx)
-			return requeueResult, err
-		}
-
 		// Suspend or stop job to proceed update.
 		if recorded.Revision.IsUpdateTriggered() && isJobUpdate(observed.revisions, observed.cluster) {
 			log.Info("Preparing job update")

--- a/controllers/flinkcluster/flinkcluster_updater.go
+++ b/controllers/flinkcluster/flinkcluster_updater.go
@@ -678,7 +678,8 @@ func (updater *ClusterStatusUpdater) deriveJobStatus(ctx context.Context) *v1bet
 			newJob.Name = observedFlinkJob.Name
 		}
 		tmpState := getFlinkJobDeploymentState(observedFlinkJob.State)
-		if observedSubmitter.job == nil || tmpState != v1beta1.JobStateSucceeded {
+		if observedSubmitter.job == nil ||
+			(observedSubmitter.job.Status.Failed < 1 && tmpState != v1beta1.JobStateSucceeded) {
 			newJobState = tmpState
 			break
 		}


### PR DESCRIPTION
If the job submitter fails, there is no point in running the job anymore. Kill the job.

Fixes https://github.com/spotify/flink-on-k8s-operator/issues/720