### PR TITLE
Restore client-side rate limiting on API server requests

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,6 +45,11 @@ var (
 	setupLog = ctrl.Log.WithName("setup")
 )
 
+const (
+	defaultQPS   = float32(20)
+	defaultBurst = 30
+)
+
 var (
 	metricsAddr             = flag.String("metrics-addr", ":8443", "The address the metric endpoint binds to.")
 	secureMetrics           = flag.Bool("secure-metrics", true, "Serve metrics over HTTPS with authn/authz via controller-runtime.")
@@ -52,6 +57,8 @@ var (
 	leaderElectionID        = flag.String("leader-election-id", "flink-operator-lock", "The name that leader election will use for holding the leader lock")
 	watchNamespace          = flag.String("watch-namespace", "", "Watch custom resources in the namespace, ignore other namespaces. If empty, all namespaces will be watched.")
 	maxConcurrentReconciles = flag.Int("max-concurrent-reconciles", 1, "The maximum number of concurrent Reconciles which can be run. Defaults to 1.")
+	qps                     = flag.Float64("kube-api-qps", float64(defaultQPS), "Maximum sustained queries per second to the API server.")
+	burst                   = flag.Int("kube-api-burst", defaultBurst, "Maximum burst queries per second to the API server.")
 )
 
 func init() {
@@ -94,7 +101,14 @@ func main() {
 		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	// Restore client-side rate limiting.
+	// controller-runtime v0.21.0 changed GetConfigOrDie() to set QPS=-1,
+	// disabling client-side rate limiting in favor of server-side APF.
+	restConfig := ctrl.GetConfigOrDie()
+	restConfig.QPS = float32(*qps)
+	restConfig.Burst = *burst
+
+	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme:         scheme,
 		Metrics:        metricsServerOptions,
 		LeaderElection: *enableLeaderElection,


### PR DESCRIPTION
## Summary

- controller-runtime v0.21.0 changed `GetConfigOrDie()` to set `QPS=-1`, completely disabling client-side rate limiting in favor of server-side API Priority and Fairness (APF)
- Without rate limiting, the operator can overwhelm the API server under production load (many FlinkCluster resources), causing HTTP 429 errors
- These 429 errors interact with a pre-existing bug in `updateClusterStatus` (inverted `IgnoreNotFound` — see #977) where transient errors are silently swallowed, causing status updates to be dropped and jobs to get stuck in Running state
- Restores the previous defaults: `QPS=20`, `Burst=30` (20 requests/second with bursts of 30)