### PR TITLE
 Fix reactive scheduler deadlock blocking JobManager recreation during updates

### DIFF
--- a/controllers/flinkcluster/flinkcluster_util.go
+++ b/controllers/flinkcluster/flinkcluster_util.go
@@ -528,8 +528,20 @@ func shouldUpdateCluster(observed *ObservedClusterState) bool {
 		return observed.updateState == UpdateStateInProgress
 	}
 
+	if observed.updateState != UpdateStateInProgress {
+		return false
+	}
+
+	// With the reactive/adaptive scheduler, the job may bounce back to an active
+	// state before the operator finishes updating components (e.g., recreating the
+	// JM StatefulSet). If a savepoint was triggered for an update, allow the update
+	// to proceed regardless of the current job state.
+	if sp := observed.cluster.Status.Savepoint; sp != nil && sp.TriggerReason == v1beta1.SavepointReasonUpdate {
+		return true
+	}
+
 	var job = observed.cluster.Status.Components.Job
-	return !job.IsActive() && observed.updateState == UpdateStateInProgress
+	return !job.IsActive()
 }
 
 func shouldRecreateOnUpdate(observed *ObservedClusterState) bool {

--- a/controllers/flinkcluster/flinkcluster_util.go
+++ b/controllers/flinkcluster/flinkcluster_util.go
@@ -535,9 +535,11 @@ func shouldUpdateCluster(observed *ObservedClusterState) bool {
 	// With the reactive/adaptive scheduler, the job may bounce back to RUNNING
 	// after the savepoint completes but before the operator recreates the
 	// JobManager StatefulSet. This would block the update indefinitely since
-	// job.IsActive() returns true. If a savepoint was already triggered for this
-	// update, it is safe to proceed regardless of the current job state.
-	if sp := observed.cluster.Status.Savepoint; sp != nil && sp.TriggerReason == v1beta1.SavepointReasonUpdate {
+	// job.IsActive() returns true. Once the update savepoint completed
+	// successfully, it is safe to proceed regardless of the current job state.
+	if sp := observed.cluster.Status.Savepoint; sp != nil &&
+		sp.TriggerReason == v1beta1.SavepointReasonUpdate &&
+		sp.State == v1beta1.SavepointStateSucceeded {
 		return true
 	}
 

--- a/controllers/flinkcluster/flinkcluster_util.go
+++ b/controllers/flinkcluster/flinkcluster_util.go
@@ -532,16 +532,17 @@ func shouldUpdateCluster(observed *ObservedClusterState) bool {
 		return false
 	}
 
-	// With the reactive/adaptive scheduler, the job may bounce back to an active
-	// state before the operator finishes updating components (e.g., recreating the
-	// JM StatefulSet). If a savepoint was triggered for an update, allow the update
-	// to proceed regardless of the current job state.
+	// With the reactive/adaptive scheduler, the job may bounce back to RUNNING
+	// after the savepoint completes but before the operator recreates the
+	// JobManager StatefulSet. This would block the update indefinitely since
+	// job.IsActive() returns true. If a savepoint was already triggered for this
+	// update, it is safe to proceed regardless of the current job state.
 	if sp := observed.cluster.Status.Savepoint; sp != nil && sp.TriggerReason == v1beta1.SavepointReasonUpdate {
 		return true
 	}
 
 	var job = observed.cluster.Status.Components.Job
-	return !job.IsActive()
+	return !job.IsActive() && observed.updateState == UpdateStateInProgress
 }
 
 func shouldRecreateOnUpdate(observed *ObservedClusterState) bool {

--- a/controllers/flinkcluster/flinkcluster_util_test.go
+++ b/controllers/flinkcluster/flinkcluster_util_test.go
@@ -325,8 +325,7 @@ func TestGetUpdateState(t *testing.T) {
 }
 
 func TestShouldUpdateCluster(t *testing.T) {
-	// Active job with update savepoint should return true.
-	t.Run("active job with update savepoint", func(t *testing.T) {
+	t.Run("active job with completed update savepoint", func(t *testing.T) {
 		observed := &ObservedClusterState{
 			updateState: UpdateStateInProgress,
 			cluster: &v1beta1.FlinkCluster{
@@ -339,12 +338,43 @@ func TestShouldUpdateCluster(t *testing.T) {
 					},
 					Savepoint: &v1beta1.SavepointStatus{
 						TriggerReason: v1beta1.SavepointReasonUpdate,
+						State:         v1beta1.SavepointStateSucceeded,
 					},
 				},
 			},
 		}
 		assert.Equal(t, shouldUpdateCluster(observed), true)
 	})
+
+	for _, tc := range []struct {
+		name  string
+		state string
+	}{
+		{name: "active job with failed update savepoint", state: v1beta1.SavepointStateFailed},
+		{name: "active job with trigger failed update savepoint", state: v1beta1.SavepointStateTriggerFailed},
+		{name: "active job with in progress update savepoint", state: v1beta1.SavepointStateInProgress},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			observed := &ObservedClusterState{
+				updateState: UpdateStateInProgress,
+				cluster: &v1beta1.FlinkCluster{
+					Spec: v1beta1.FlinkClusterSpec{
+						Job: &v1beta1.JobSpec{},
+					},
+					Status: v1beta1.FlinkClusterStatus{
+						Components: v1beta1.FlinkClusterComponentsStatus{
+							Job: &v1beta1.JobStatus{State: v1beta1.JobStateRunning},
+						},
+						Savepoint: &v1beta1.SavepointStatus{
+							TriggerReason: v1beta1.SavepointReasonUpdate,
+							State:         tc.state,
+						},
+					},
+				},
+			}
+			assert.Equal(t, shouldUpdateCluster(observed), false)
+		})
+	}
 
 	// Active job without update savepoint should return false.
 	t.Run("active job without update savepoint", func(t *testing.T) {

--- a/controllers/flinkcluster/flinkcluster_util_test.go
+++ b/controllers/flinkcluster/flinkcluster_util_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package flinkcluster
 
 import (
+	"encoding/json"
 	"os"
 	"testing"
 
@@ -321,6 +322,115 @@ func TestGetUpdateState(t *testing.T) {
 	}
 	state = getUpdateState(&observed)
 	assert.Equal(t, state, UpdateStateFinished)
+}
+
+func TestShouldUpdateCluster(t *testing.T) {
+	// Active job with update savepoint should return true.
+	t.Run("active job with update savepoint", func(t *testing.T) {
+		observed := &ObservedClusterState{
+			updateState: UpdateStateInProgress,
+			cluster: &v1beta1.FlinkCluster{
+				Spec: v1beta1.FlinkClusterSpec{
+					Job: &v1beta1.JobSpec{},
+				},
+				Status: v1beta1.FlinkClusterStatus{
+					Components: v1beta1.FlinkClusterComponentsStatus{
+						Job: &v1beta1.JobStatus{State: v1beta1.JobStateRunning},
+					},
+					Savepoint: &v1beta1.SavepointStatus{
+						TriggerReason: v1beta1.SavepointReasonUpdate,
+					},
+				},
+			},
+		}
+		assert.Equal(t, shouldUpdateCluster(observed), true)
+	})
+
+	// Active job without update savepoint should return false.
+	t.Run("active job without update savepoint", func(t *testing.T) {
+		observed := &ObservedClusterState{
+			updateState: UpdateStateInProgress,
+			cluster: &v1beta1.FlinkCluster{
+				Spec: v1beta1.FlinkClusterSpec{
+					Job: &v1beta1.JobSpec{},
+				},
+				Status: v1beta1.FlinkClusterStatus{
+					Components: v1beta1.FlinkClusterComponentsStatus{
+						Job: &v1beta1.JobStatus{State: v1beta1.JobStateRunning},
+					},
+				},
+			},
+		}
+		assert.Equal(t, shouldUpdateCluster(observed), false)
+	})
+
+	// Inactive job without savepoint should return true.
+	t.Run("inactive job without savepoint", func(t *testing.T) {
+		observed := &ObservedClusterState{
+			updateState: UpdateStateInProgress,
+			cluster: &v1beta1.FlinkCluster{
+				Spec: v1beta1.FlinkClusterSpec{
+					Job: &v1beta1.JobSpec{},
+				},
+				Status: v1beta1.FlinkClusterStatus{
+					Components: v1beta1.FlinkClusterComponentsStatus{
+						Job: &v1beta1.JobStatus{State: v1beta1.JobStateCancelled},
+					},
+				},
+			},
+		}
+		assert.Equal(t, shouldUpdateCluster(observed), true)
+	})
+
+	// Update not in progress should return false.
+	t.Run("update not in progress", func(t *testing.T) {
+		observed := &ObservedClusterState{
+			updateState: UpdateStateFinished,
+			cluster: &v1beta1.FlinkCluster{
+				Spec: v1beta1.FlinkClusterSpec{
+					Job: &v1beta1.JobSpec{},
+				},
+				Status: v1beta1.FlinkClusterStatus{
+					Components: v1beta1.FlinkClusterComponentsStatus{
+						Job: &v1beta1.JobStatus{State: v1beta1.JobStateCancelled},
+					},
+				},
+			},
+		}
+		assert.Equal(t, shouldUpdateCluster(observed), false)
+	})
+
+	// Scale update bypasses job state and savepoint checks.
+	t.Run("scale update with active job", func(t *testing.T) {
+		revisions := []*appsv1.ControllerRevision{
+			{Revision: 1, Data: runtime.RawExtension{Raw: mustMarshal(t, map[string]any{"spec": map[string]any{"taskManager": map[string]any{"replicas": float64(2)}}})}},
+			{Revision: 2, Data: runtime.RawExtension{Raw: mustMarshal(t, map[string]any{"spec": map[string]any{"taskManager": map[string]any{"replicas": float64(4)}}})}},
+		}
+		observed := &ObservedClusterState{
+			updateState: UpdateStateInProgress,
+			revisions:   revisions,
+			cluster: &v1beta1.FlinkCluster{
+				Spec: v1beta1.FlinkClusterSpec{
+					Job: &v1beta1.JobSpec{},
+				},
+				Status: v1beta1.FlinkClusterStatus{
+					Components: v1beta1.FlinkClusterComponentsStatus{
+						Job: &v1beta1.JobStatus{State: v1beta1.JobStateRunning},
+					},
+				},
+			},
+		}
+		assert.Equal(t, shouldUpdateCluster(observed), true)
+	})
+}
+
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+	return data
 }
 
 func TestHasTimeElapsed(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes a deadlock where `shouldUpdateCluster()` blocks component recreation when the reactive/adaptive scheduler restarts the cancelled job before the operator finishes updating components
- Companion fix to #959, which addressed job resubmission -- this addresses the prior step where the component update itself gets stuck

## Problem

During an in-place update, the operator takes a savepoint and cancels the running job. With the default scheduler, the job stays cancelled and `shouldUpdateCluster()` sees `!job.IsActive() == true`, allowing component recreation to proceed.

With the reactive/adaptive scheduler, the job is automatically restarted to RUNNING immediately after cancellation. `shouldUpdateCluster()` then sees an active job and returns `false`, blocking the JobManager StatefulSet recreation indefinitely. The operator and the scheduler are deadlocked -- the operator waits for the job to stop, the scheduler keeps restarting it.

## Fix

Proceed with component updates only after an update-triggered savepoint has
  completed successfully -- i.e. when the cluster status has a savepoint with
  `TriggerReason == SavepointReasonUpdate` AND `State == SavepointStateSucceeded`.
  In that case, state is durably saved and the cancellation was intentional, so
  it is safe to recreate the JobManager StatefulSet regardless of whether the
  reactive/adaptive scheduler has bounced the job back to RUNNING.

  If the savepoint is still `InProgress`, `Failed`, or `TriggerFailed`, no bypass
  applies and the existing `!job.IsActive()` path is used -- the update keeps
  waiting rather than destroying the StatefulSet when state wasn't saved.

  The `!job.IsActive()` fallback is preserved for the non-reactive-scheduler path.
