### PR TITLE
ci: declare per-job permissions on ci, release-drafter, release-helm-charts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: Test
 jobs:
   ci:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out the repo
         uses: actions/checkout@v6

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
       - uses: release-drafter/release-drafter@v7
         env:

--- a/.github/workflows/release-helm-charts.yaml
+++ b/.github/workflows/release-helm-charts.yaml
@@ -6,6 +6,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Three workflows don't currently declare a `permissions:` block, so the workflow `GITHUB_TOKEN` falls back to whatever the repo default grants. This patch pins each job to its minimum:

- `.github/workflows/ci.yml` -- `contents: read`. The single job only checks out, sets up Go, and runs `make docker-build`. No GitHub API write.
- `.github/workflows/release-drafter.yml` -- `contents: write`, `pull-requests: read`. `release-drafter/release-drafter@v7` reads merged PRs and writes the draft release.
- `.github/workflows/release-helm-charts.yaml` -- `contents: write`. `regadas/chart-releaser-action@v1` creates a GitHub release for each packaged chart and commits `index.yaml` to `gh-pages`. The action receives `CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}`, so the workflow token needs `contents: write`.

The shape is consistent with `codeql-analysis.yml` (`actions: read`, `contents: read`, `security-events: write`) and `publish.yml` (`packages: write`, `contents: write`), both of which already pin per-job scopes.

No behavioural change to any of the three workflows.

Third-party action exposure: `release-drafter/release-drafter`, `regadas/chart-releaser-action`, `azure/setup-helm`. Explicit per-job scopes narrow the blast radius if any is compromised (cf. tj-actions/changed-files CVE-2025-30066).