### PR TITLE
feat: Allow specifying savepoint format type

### DIFF
--- a/apis/flinkcluster/v1beta1/assets/test/flinkcluster_type_expected.yaml
+++ b/apis/flinkcluster/v1beta1/assets/test/flinkcluster_type_expected.yaml
@@ -40,6 +40,7 @@ spec:
   job:
     jarFile: ./examples/streaming/StateMachineExample.jar
     allowNonRestoredState: false
+    savepointFormatType: CANONICAL
     noLoggingToStdout: false
     restartPolicy: Never
     cleanupPolicy:

--- a/apis/flinkcluster/v1beta1/flinkcluster_types.go
+++ b/apis/flinkcluster/v1beta1/flinkcluster_types.go
@@ -576,7 +576,7 @@ type JobSpec struct {
 	// _(Optional)_ Savepoints dir where to store savepoints of the job.
 	SavepointsDir *string `json:"savepointsDir,omitempty"`
 
-	// _(Optional)_ Savepoint format type, "CANONICAL" or "NATIVE", default: "CANONICAL".
+	// _(Optional)_ Savepoint format type, "CANONICAL" or "NATIVE", default: "CANONICAL". Requires Flink 1.15 or later.
 	// +kubebuilder:validation:Enum=CANONICAL;NATIVE
 	// +kubebuilder:default:=CANONICAL
 	SavepointFormatType *SavepointFormatType `json:"savepointFormatType,omitempty"`

--- a/apis/flinkcluster/v1beta1/flinkcluster_types.go
+++ b/apis/flinkcluster/v1beta1/flinkcluster_types.go
@@ -138,7 +138,6 @@ const (
 )
 
 // SavepointFormatType specifies the binary format of a savepoint.
-// +kubebuilder:validation:Enum=CANONICAL;NATIVE
 type SavepointFormatType string
 
 const (

--- a/apis/flinkcluster/v1beta1/flinkcluster_types.go
+++ b/apis/flinkcluster/v1beta1/flinkcluster_types.go
@@ -137,6 +137,15 @@ const (
 	SavepointReasonUpdate        SavepointReason = "update"
 )
 
+// SavepointFormatType specifies the binary format of a savepoint.
+// +kubebuilder:validation:Enum=CANONICAL;NATIVE
+type SavepointFormatType string
+
+const (
+	SavepointFormatTypeCanonical SavepointFormatType = "CANONICAL"
+	SavepointFormatTypeNative    SavepointFormatType = "NATIVE"
+)
+
 // ImageSpec defines Flink image of JobManager and TaskManager containers.
 type ImageSpec struct {
 	// Flink image name.
@@ -567,6 +576,11 @@ type JobSpec struct {
 
 	// _(Optional)_ Savepoints dir where to store savepoints of the job.
 	SavepointsDir *string `json:"savepointsDir,omitempty"`
+
+	// _(Optional)_ Savepoint format type, "CANONICAL" or "NATIVE", default: "CANONICAL".
+	// +kubebuilder:validation:Enum=CANONICAL;NATIVE
+	// +kubebuilder:default:=CANONICAL
+	SavepointFormatType *SavepointFormatType `json:"savepointFormatType,omitempty"`
 
 	// _(Optional)_ Should take savepoint before updating job, default: `true`.
 	// If this is set as false, maxStateAgeToRestoreSeconds must be provided to limit the savepoint age to restore.

--- a/apis/flinkcluster/v1beta1/flinkcluster_types.go
+++ b/apis/flinkcluster/v1beta1/flinkcluster_types.go
@@ -959,8 +959,8 @@ type SavepointStatus struct {
 	// Savepoint state.
 	State string `json:"state"`
 
-	// Savepoint format type, "CANONICAL" or "NATIVE".
-	FormatType string `json:"formatType,omitempty"`
+	// Savepoint format type.
+	FormatType SavepointFormatType `json:"formatType,omitempty"`
 
 	// Savepoint message.
 	Message string `json:"message,omitempty"`

--- a/apis/flinkcluster/v1beta1/flinkcluster_types.go
+++ b/apis/flinkcluster/v1beta1/flinkcluster_types.go
@@ -960,6 +960,9 @@ type SavepointStatus struct {
 	// Savepoint state.
 	State string `json:"state"`
 
+	// Savepoint format type, "CANONICAL" or "NATIVE".
+	FormatType string `json:"formatType,omitempty"`
+
 	// Savepoint message.
 	Message string `json:"message,omitempty"`
 }

--- a/apis/flinkcluster/v1beta1/zz_generated.deepcopy.go
+++ b/apis/flinkcluster/v1beta1/zz_generated.deepcopy.go
@@ -751,6 +751,11 @@ func (in *JobSpec) DeepCopyInto(out *JobSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SavepointFormatType != nil {
+		in, out := &in.SavepointFormatType, &out.SavepointFormatType
+		*out = new(SavepointFormatType)
+		**out = **in
+	}
 	if in.TakeSavepointOnUpdate != nil {
 		in, out := &in.TakeSavepointOnUpdate, &out.TakeSavepointOnUpdate
 		*out = new(bool)

--- a/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
+++ b/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
@@ -9727,6 +9727,8 @@ spec:
                   type: object
                 savepoint:
                   properties:
+                    formatType:
+                      type: string
                     jobID:
                       type: string
                     message:

--- a/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
+++ b/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
@@ -1539,6 +1539,16 @@ spec:
                         - Never
                         - FromSavepointOnFailure
                       type: string
+                    savepointFormatType:
+                      allOf:
+                        - enum:
+                            - CANONICAL
+                            - NATIVE
+                        - enum:
+                            - CANONICAL
+                            - NATIVE
+                      default: CANONICAL
+                      type: string
                     savepointGeneration:
                       format: int32
                       type: integer

--- a/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
+++ b/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
@@ -1540,14 +1540,10 @@ spec:
                         - FromSavepointOnFailure
                       type: string
                     savepointFormatType:
-                      allOf:
-                        - enum:
-                            - CANONICAL
-                            - NATIVE
-                        - enum:
-                            - CANONICAL
-                            - NATIVE
                       default: CANONICAL
+                      enum:
+                        - CANONICAL
+                        - NATIVE
                       type: string
                     savepointGeneration:
                       format: int32

--- a/controllers/flinkcluster/flinkcluster_converter.go
+++ b/controllers/flinkcluster/flinkcluster_converter.go
@@ -70,8 +70,9 @@ var (
 		"query.server.port":      {},
 		"rest.port":              {},
 	}
-	v10, _ = version.NewVersion("1.10")
-	v20, _ = version.NewVersion("2.0")
+	v10, _  = version.NewVersion("1.10")
+	v115, _ = version.NewVersion("1.15")
+	v20, _  = version.NewVersion("2.0")
 )
 
 // Gets the desired state of a cluster.

--- a/controllers/flinkcluster/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/util/retry"
 
 	"github.com/go-logr/logr"
+	"github.com/hashicorp/go-version"
 	v1beta1 "github.com/spotify/flink-on-k8s-operator/apis/flinkcluster/v1beta1"
 	"github.com/spotify/flink-on-k8s-operator/internal/batchscheduler"
 	schedulerTypes "github.com/spotify/flink-on-k8s-operator/internal/batchscheduler/types"
@@ -872,7 +873,7 @@ func (reconciler *ClusterReconciler) triggerSavepoint(
 	var message string
 	var err error
 	log.Info(fmt.Sprintf("Trigger savepoint for %s", triggerReason), "jobID", jobID)
-	savepointTriggerID, err = reconciler.flinkClient.TriggerSavepoint(apiBaseURL, jobID, *cluster.Spec.Job.SavepointsDir, cancel, string(*cluster.Spec.Job.SavepointFormatType))
+	savepointTriggerID, err = reconciler.flinkClient.TriggerSavepoint(apiBaseURL, jobID, *cluster.Spec.Job.SavepointsDir, cancel, savepointFormatType(cluster))
 	if err != nil {
 		// limit message size to 1KiB
 		if message = err.Error(); len(message) > 1024 {
@@ -888,6 +889,19 @@ func (reconciler *ClusterReconciler) triggerSavepoint(
 	newSavepointStatus := reconciler.getNewSavepointStatus(triggerID, triggerReason, message, triggerSuccess)
 
 	return newSavepointStatus, err
+}
+
+// savepointFormatType returns the format type to pass to the Flink REST API,
+// or empty string for Flink < 1.15 which does not support the formatType parameter.
+func savepointFormatType(cluster *v1beta1.FlinkCluster) string {
+	appVersion, _ := version.NewVersion(cluster.Spec.FlinkVersion)
+	if appVersion == nil || appVersion.LessThan(v115) {
+		return ""
+	}
+	if cluster.Spec.Job == nil || cluster.Spec.Job.SavepointFormatType == nil {
+		return ""
+	}
+	return string(*cluster.Spec.Job.SavepointFormatType)
 }
 
 func (reconciler *ClusterReconciler) updateStatus(

--- a/controllers/flinkcluster/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler.go
@@ -871,9 +871,10 @@ func (reconciler *ClusterReconciler) triggerSavepoint(
 	var savepointTriggerID *flink.SavepointTriggerID
 	var triggerID string
 	var message string
+	var formatType = savepointFormatType(cluster)
 	var err error
 	log.Info(fmt.Sprintf("Trigger savepoint for %s", triggerReason), "jobID", jobID)
-	savepointTriggerID, err = reconciler.flinkClient.TriggerSavepoint(apiBaseURL, jobID, *cluster.Spec.Job.SavepointsDir, cancel, savepointFormatType(cluster))
+	savepointTriggerID, err = reconciler.flinkClient.TriggerSavepoint(apiBaseURL, jobID, *cluster.Spec.Job.SavepointsDir, cancel, formatType)
 	if err != nil {
 		// limit message size to 1KiB
 		if message = err.Error(); len(message) > 1024 {
@@ -886,7 +887,7 @@ func (reconciler *ClusterReconciler) triggerSavepoint(
 		triggerID = savepointTriggerID.RequestID
 		log.Info("Successfully savepoint triggered", "jobID", jobID, "triggerID", triggerID)
 	}
-	newSavepointStatus := reconciler.getNewSavepointStatus(triggerID, triggerReason, message, triggerSuccess)
+	newSavepointStatus := reconciler.getNewSavepointStatus(triggerID, triggerReason, message, triggerSuccess, formatType)
 
 	return newSavepointStatus, err
 }
@@ -1013,7 +1014,7 @@ func (reconciler *ClusterReconciler) updateJobDeployStatus(ctx context.Context) 
 }
 
 // getNewSavepointStatus returns newly triggered savepoint status.
-func (reconciler *ClusterReconciler) getNewSavepointStatus(triggerID string, triggerReason v1beta1.SavepointReason, message string, triggerSuccess bool) *v1beta1.SavepointStatus {
+func (reconciler *ClusterReconciler) getNewSavepointStatus(triggerID string, triggerReason v1beta1.SavepointReason, message string, triggerSuccess bool, formatType string) *v1beta1.SavepointStatus {
 	var jobID = reconciler.getFlinkJobID()
 	var savepointState string
 	var now string
@@ -1032,6 +1033,7 @@ func (reconciler *ClusterReconciler) getNewSavepointStatus(triggerID string, tri
 		UpdateTime:    now,
 		Message:       message,
 		State:         savepointState,
+		FormatType:    formatType,
 	}
 	return savepointStatus
 }

--- a/controllers/flinkcluster/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler.go
@@ -895,7 +895,7 @@ func (reconciler *ClusterReconciler) triggerSavepoint(
 // or empty string for Flink < 1.15 which does not support the formatType parameter.
 func savepointFormatType(cluster *v1beta1.FlinkCluster) string {
 	appVersion, _ := version.NewVersion(cluster.Spec.FlinkVersion)
-	if appVersion == nil || appVersion.LessThan(v115) {
+	if appVersion != nil && appVersion.LessThan(v115) {
 		return ""
 	}
 	if cluster.Spec.Job == nil || cluster.Spec.Job.SavepointFormatType == nil {

--- a/controllers/flinkcluster/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler.go
@@ -874,7 +874,7 @@ func (reconciler *ClusterReconciler) triggerSavepoint(
 	var formatType = savepointFormatType(cluster)
 	var err error
 	log.Info(fmt.Sprintf("Trigger savepoint for %s", triggerReason), "jobID", jobID)
-	savepointTriggerID, err = reconciler.flinkClient.TriggerSavepoint(apiBaseURL, jobID, *cluster.Spec.Job.SavepointsDir, cancel, formatType)
+	savepointTriggerID, err = reconciler.flinkClient.TriggerSavepoint(apiBaseURL, jobID, *cluster.Spec.Job.SavepointsDir, cancel, string(formatType))
 	if err != nil {
 		// limit message size to 1KiB
 		if message = err.Error(); len(message) > 1024 {
@@ -893,8 +893,8 @@ func (reconciler *ClusterReconciler) triggerSavepoint(
 }
 
 // savepointFormatType returns the format type to pass to the Flink REST API,
-// or empty string for Flink < 1.15 which does not support the formatType parameter.
-func savepointFormatType(cluster *v1beta1.FlinkCluster) string {
+// or empty for Flink < 1.15 which does not support the formatType parameter.
+func savepointFormatType(cluster *v1beta1.FlinkCluster) v1beta1.SavepointFormatType {
 	appVersion, _ := version.NewVersion(cluster.Spec.FlinkVersion)
 	if appVersion == nil || appVersion.LessThan(v115) {
 		return ""
@@ -902,7 +902,7 @@ func savepointFormatType(cluster *v1beta1.FlinkCluster) string {
 	if cluster.Spec.Job == nil || cluster.Spec.Job.SavepointFormatType == nil {
 		return ""
 	}
-	return string(*cluster.Spec.Job.SavepointFormatType)
+	return *cluster.Spec.Job.SavepointFormatType
 }
 
 func (reconciler *ClusterReconciler) updateStatus(
@@ -1014,7 +1014,7 @@ func (reconciler *ClusterReconciler) updateJobDeployStatus(ctx context.Context) 
 }
 
 // getNewSavepointStatus returns newly triggered savepoint status.
-func (reconciler *ClusterReconciler) getNewSavepointStatus(triggerID string, triggerReason v1beta1.SavepointReason, message string, triggerSuccess bool, formatType string) *v1beta1.SavepointStatus {
+func (reconciler *ClusterReconciler) getNewSavepointStatus(triggerID string, triggerReason v1beta1.SavepointReason, message string, triggerSuccess bool, formatType v1beta1.SavepointFormatType) *v1beta1.SavepointStatus {
 	var jobID = reconciler.getFlinkJobID()
 	var savepointState string
 	var now string

--- a/controllers/flinkcluster/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler.go
@@ -871,9 +871,8 @@ func (reconciler *ClusterReconciler) triggerSavepoint(
 	var triggerID string
 	var message string
 	var err error
-
 	log.Info(fmt.Sprintf("Trigger savepoint for %s", triggerReason), "jobID", jobID)
-	savepointTriggerID, err = reconciler.flinkClient.TriggerSavepoint(apiBaseURL, jobID, *cluster.Spec.Job.SavepointsDir, cancel)
+	savepointTriggerID, err = reconciler.flinkClient.TriggerSavepoint(apiBaseURL, jobID, *cluster.Spec.Job.SavepointsDir, cancel, string(*cluster.Spec.Job.SavepointFormatType))
 	if err != nil {
 		// limit message size to 1KiB
 		if message = err.Error(); len(message) > 1024 {

--- a/controllers/flinkcluster/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler.go
@@ -710,12 +710,13 @@ func (reconciler *ClusterReconciler) cancelFlinkJob(ctx context.Context, jobID s
 
 	if takeSavepoint && canTakeSavepoint(reconciler.observed.cluster) {
 		log.Info("Stopping job with savepoint", "jobID", jobID)
+		formatType := savepointFormatType(reconciler.observed.cluster)
 		triggerID, err := reconciler.flinkClient.StopJobWithSavepoint(
-			apiBaseURL, jobID, *reconciler.observed.cluster.Spec.Job.SavepointsDir)
+			apiBaseURL, jobID, *reconciler.observed.cluster.Spec.Job.SavepointsDir, string(formatType))
 		if err != nil {
 			return err
 		}
-		newSavepointStatus := reconciler.getNewSavepointStatus(triggerID.RequestID, v1beta1.SavepointReasonJobCancel, "", true)
+		newSavepointStatus := reconciler.getNewSavepointStatus(triggerID.RequestID, v1beta1.SavepointReasonJobCancel, "", true, formatType)
 		var newControlStatus *v1beta1.FlinkClusterControlStatus
 		reconciler.updateStatus(ctx, &newSavepointStatus, &newControlStatus)
 		location, err := reconciler.waitForSavepointCompleted(ctx, apiBaseURL, jobID, triggerID.RequestID)

--- a/controllers/flinkcluster/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler.go
@@ -896,7 +896,7 @@ func (reconciler *ClusterReconciler) triggerSavepoint(
 // or empty string for Flink < 1.15 which does not support the formatType parameter.
 func savepointFormatType(cluster *v1beta1.FlinkCluster) string {
 	appVersion, _ := version.NewVersion(cluster.Spec.FlinkVersion)
-	if appVersion != nil && appVersion.LessThan(v115) {
+	if appVersion == nil || appVersion.LessThan(v115) {
 		return ""
 	}
 	if cluster.Spec.Job == nil || cluster.Spec.Job.SavepointFormatType == nil {

--- a/controllers/flinkcluster/flinkcluster_reconciler_test.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler_test.go
@@ -2,13 +2,15 @@ package flinkcluster
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
-	"sync/atomic"
-	"testing"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
+	"testing"
 
 	"github.com/go-logr/logr"
 	v1beta1 "github.com/spotify/flink-on-k8s-operator/apis/flinkcluster/v1beta1"
@@ -310,9 +312,13 @@ func TestReconcileJobKeepsSubmitterAtNextRevision(t *testing.T) {
 func TestCancelFlinkJob_StopWithSavepoint_Success(t *testing.T) {
 	// given: Flink REST API that completes savepoint after 2 in-progress polls
 	var pollCount atomic.Int32
+	var stopBody map[string]interface{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/jobs/job-123/stop":
+			body, err := io.ReadAll(r.Body)
+			assert.NilError(t, err)
+			assert.NilError(t, json.Unmarshal(body, &stopBody))
 			w.Header().Set("Content-Type", "application/json")
 			fmt.Fprint(w, `{"request-id": "trigger-abc"}`)
 
@@ -332,9 +338,12 @@ func TestCancelFlinkJob_StopWithSavepoint_Success(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// and: a running cluster with savepoints configured
+	// and: a running Flink 1.15 cluster with native savepoints configured
 	savepointsDir := "s3://bucket/savepoints"
+	formatType := v1beta1.SavepointFormatTypeNative
 	cluster := newTestClusterWithJob(&savepointsDir, nil)
+	cluster.Spec.FlinkVersion = "1.15.0"
+	cluster.Spec.Job.SavepointFormatType = &formatType
 	reconciler := newTestReconciler(cluster, newRedirectingHTTPClient(server.URL))
 
 	// when: cancelFlinkJob is called with takeSavepoint=true
@@ -359,6 +368,14 @@ func TestCancelFlinkJob_StopWithSavepoint_Success(t *testing.T) {
 	if sp.TriggerID != "trigger-abc" {
 		t.Errorf("expected trigger ID %q, got %q", "trigger-abc", sp.TriggerID)
 	}
+	if sp.FormatType != v1beta1.SavepointFormatTypeNative {
+		t.Errorf("expected format type %q, got %q", v1beta1.SavepointFormatTypeNative, sp.FormatType)
+	}
+	assert.DeepEqual(t, stopBody, map[string]interface{}{
+		"targetDirectory": savepointsDir,
+		"drain":           false,
+		"formatType":      "NATIVE",
+	})
 
 	// and: the job status records the savepoint location as the job's final savepoint
 	job := requireJobStatus(t, reconciler, cluster)

--- a/controllers/flinkcluster/flinkcluster_util.go
+++ b/controllers/flinkcluster/flinkcluster_util.go
@@ -202,6 +202,7 @@ func newRevisionDataPatch(cluster *v1beta1.FlinkCluster) ([]byte, error) {
 		c.Spec.Job.RestartPolicy = nil
 		c.Spec.Job.CancelRequested = nil
 		c.Spec.Job.SavepointGeneration = 0
+		c.Spec.Job.SavepointFormatType = nil
 	} else {
 		c = cluster
 	}

--- a/controllers/flinkcluster/flinkcluster_util_test.go
+++ b/controllers/flinkcluster/flinkcluster_util_test.go
@@ -614,7 +614,7 @@ func TestSavepointFormatType(t *testing.T) {
 		name         string
 		flinkVersion string
 		job          *v1beta1.JobSpec
-		expected     string
+		expected     v1beta1.SavepointFormatType
 	}{
 		{
 			name:         "empty version returns empty",
@@ -638,13 +638,13 @@ func TestSavepointFormatType(t *testing.T) {
 			name:         "Flink 1.15.0 returns NATIVE",
 			flinkVersion: "1.15.0",
 			job:          &v1beta1.JobSpec{SavepointFormatType: &native},
-			expected:     "NATIVE",
+			expected:     native,
 		},
 		{
 			name:         "Flink 1.15.0 returns CANONICAL",
 			flinkVersion: "1.15.0",
 			job:          &v1beta1.JobSpec{SavepointFormatType: &canonical},
-			expected:     "CANONICAL",
+			expected:     canonical,
 		},
 		{
 			name:         "Flink 1.15 nil formatType returns empty",

--- a/controllers/flinkcluster/flinkcluster_util_test.go
+++ b/controllers/flinkcluster/flinkcluster_util_test.go
@@ -150,6 +150,36 @@ func TestNewRevision(t *testing.T) {
 		expectedRevision)
 }
 
+func TestNewRevisionDataPatchExcludesSavepointFormatType(t *testing.T) {
+	native := v1beta1.SavepointFormatTypeNative
+	canonical := v1beta1.SavepointFormatTypeCanonical
+	savepointDir := "/savepoint_dir"
+
+	baseCluster := func(ft *v1beta1.SavepointFormatType) *v1beta1.FlinkCluster {
+		return &v1beta1.FlinkCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "mycluster", Namespace: "default"},
+			Spec: v1beta1.FlinkClusterSpec{
+				Job: &v1beta1.JobSpec{
+					SavepointsDir:       &savepointDir,
+					SavepointFormatType: ft,
+				},
+			},
+		}
+	}
+
+	patchNil, err := newRevisionDataPatch(baseCluster(nil))
+	assert.NilError(t, err)
+	patchCanonical, err := newRevisionDataPatch(baseCluster(&canonical))
+	assert.NilError(t, err)
+	patchNative, err := newRevisionDataPatch(baseCluster(&native))
+	assert.NilError(t, err)
+
+	assert.Equal(t, string(patchNil), string(patchCanonical),
+		"nil vs CANONICAL should produce the same revision patch")
+	assert.Equal(t, string(patchNil), string(patchNative),
+		"nil vs NATIVE should produce the same revision patch")
+}
+
 func TestCanTakeSavepoint(t *testing.T) {
 	// session cluster
 	var cluster = v1beta1.FlinkCluster{

--- a/controllers/flinkcluster/flinkcluster_util_test.go
+++ b/controllers/flinkcluster/flinkcluster_util_test.go
@@ -575,3 +575,65 @@ func TestParseFlinkDuration_Invalid(t *testing.T) {
 		})
 	}
 }
+
+func TestSavepointFormatType(t *testing.T) {
+	native := v1beta1.SavepointFormatTypeNative
+	canonical := v1beta1.SavepointFormatTypeCanonical
+
+	tests := []struct {
+		name         string
+		flinkVersion string
+		job          *v1beta1.JobSpec
+		expected     string
+	}{
+		{
+			name:         "empty version returns empty",
+			flinkVersion: "",
+			job:          &v1beta1.JobSpec{},
+			expected:     "",
+		},
+		{
+			name:         "unparseable version returns empty",
+			flinkVersion: "latest",
+			job:          &v1beta1.JobSpec{SavepointFormatType: &native},
+			expected:     "",
+		},
+		{
+			name:         "Flink 1.14.6 always returns empty",
+			flinkVersion: "1.14.6",
+			job:          &v1beta1.JobSpec{SavepointFormatType: &canonical},
+			expected:     "",
+		},
+		{
+			name:         "Flink 1.15.0 returns NATIVE",
+			flinkVersion: "1.15.0",
+			job:          &v1beta1.JobSpec{SavepointFormatType: &native},
+			expected:     "NATIVE",
+		},
+		{
+			name:         "Flink 1.15.0 returns CANONICAL",
+			flinkVersion: "1.15.0",
+			job:          &v1beta1.JobSpec{SavepointFormatType: &canonical},
+			expected:     "CANONICAL",
+		},
+		{
+			name:         "Flink 1.15 nil formatType returns empty",
+			flinkVersion: "1.15.0",
+			job:          &v1beta1.JobSpec{},
+			expected:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := &v1beta1.FlinkCluster{
+				Spec: v1beta1.FlinkClusterSpec{
+					FlinkVersion: tt.flinkVersion,
+					Job:          tt.job,
+				},
+			}
+			got := savepointFormatType(cluster)
+			assert.Equal(t, got, tt.expected)
+		})
+	}
+}

--- a/docs/savepoints_guide.md
+++ b/docs/savepoints_guide.md
@@ -245,7 +245,8 @@ savepoints in GCS.
 ## Savepoint format
 
 Flink supports two savepoint formats: `CANONICAL` and `NATIVE`. You can control which format is used by setting the
-`savepointFormatType` property in the job spec. If not specified, Flink uses the canonical format by default.
+`savepointFormatType` property in the job spec. If not specified, Flink uses the canonical format by default. This option
+requires Flink 1.15 or later; for older or unparseable Flink versions, the operator omits the format parameter.
 
 For more details on the differences between the two formats and when to use each, see the
 [Flink documentation on savepoint formats](https://nightlies.apache.org/flink/flink-docs-stable/docs/ops/state/savepoints/#savepoint-format).

--- a/docs/savepoints_guide.md
+++ b/docs/savepoints_guide.md
@@ -241,3 +241,23 @@ Note that
 
 Usually you want to store savepoints in remote storages, see this [doc](../images/flink/README.md) on how you can store
 savepoints in GCS.
+
+## Savepoint format
+
+Flink supports two savepoint formats: `CANONICAL` and `NATIVE`. You can control which format is used by setting the
+`savepointFormatType` property in the job spec. If not specified, Flink uses the canonical format by default.
+
+For more details on the differences between the two formats and when to use each, see the
+[Flink documentation on savepoint formats](https://nightlies.apache.org/flink/flink-docs-stable/docs/ops/state/savepoints/#savepoint-format).
+
+```yaml
+apiVersion: flinkoperator.k8s.io/v1beta1
+kind: FlinkCluster
+metadata:
+  name: flinkjobcluster-sample
+spec:
+  ...
+  job:
+    savepointFormatType: NATIVE
+    ...
+```

--- a/internal/flink/client.go
+++ b/internal/flink/client.go
@@ -194,13 +194,22 @@ func (c *Client) StopJobWithSavepoint(apiBaseURL string, jobID string, dir strin
 }
 
 // TriggerSavepoint triggers an async savepoint operation.
+// formatType is optional: pass an empty string to omit it (required for Flink < 1.15).
 func (c *Client) TriggerSavepoint(apiBaseURL string, jobID string, dir string, cancel bool, formatType string) (*SavepointTriggerID, error) {
 	url := fmt.Sprintf("%s/jobs/%s/savepoints", apiBaseURL, jobID)
-	jsonStr := fmt.Sprintf(`{
-		"target-directory" : "%s",
-		"cancel-job" : %v,
-		"formatType" : "%s"
-	}`, dir, cancel, formatType)
+	var jsonStr string
+	if formatType != "" {
+		jsonStr = fmt.Sprintf(`{
+			"target-directory" : "%s",
+			"cancel-job" : %v,
+			"formatType" : "%s"
+		}`, dir, cancel, formatType)
+	} else {
+		jsonStr = fmt.Sprintf(`{
+			"target-directory" : "%s",
+			"cancel-job" : %v
+		}`, dir, cancel)
+	}
 	resp, err := c.httpClient.Post(url, "application/json", strings.NewReader(jsonStr))
 	if err != nil {
 		return nil, err

--- a/internal/flink/client.go
+++ b/internal/flink/client.go
@@ -176,13 +176,23 @@ func (c *Client) StopJob(
 }
 
 // StopJobWithSavepoint stops a job with a savepoint atomically.
-func (c *Client) StopJobWithSavepoint(apiBaseURL string, jobID string, dir string) (*SavepointTriggerID, error) {
+// formatType is optional: pass an empty string to omit it (required for Flink < 1.15).
+func (c *Client) StopJobWithSavepoint(apiBaseURL string, jobID string, dir string, formatType string) (*SavepointTriggerID, error) {
 	url := fmt.Sprintf("%s/jobs/%s/stop", apiBaseURL, jobID)
 	// TODO: Do we want to allow specifying drain flag?
-	jsonStr := fmt.Sprintf(`{
-		"targetDirectory" : "%s",
-		"drain" : false
-	}`, dir)
+	var jsonStr string
+	if formatType != "" {
+		jsonStr = fmt.Sprintf(`{
+			"targetDirectory" : "%s",
+			"drain" : false,
+			"formatType" : "%s"
+		}`, dir, formatType)
+	} else {
+		jsonStr = fmt.Sprintf(`{
+			"targetDirectory" : "%s",
+			"drain" : false
+		}`, dir)
+	}
 	resp, err := c.httpClient.Post(url, "application/json", strings.NewReader(jsonStr))
 	if err != nil {
 		return nil, err

--- a/internal/flink/client.go
+++ b/internal/flink/client.go
@@ -194,12 +194,13 @@ func (c *Client) StopJobWithSavepoint(apiBaseURL string, jobID string, dir strin
 }
 
 // TriggerSavepoint triggers an async savepoint operation.
-func (c *Client) TriggerSavepoint(apiBaseURL string, jobID string, dir string, cancel bool) (*SavepointTriggerID, error) {
+func (c *Client) TriggerSavepoint(apiBaseURL string, jobID string, dir string, cancel bool, formatType string) (*SavepointTriggerID, error) {
 	url := fmt.Sprintf("%s/jobs/%s/savepoints", apiBaseURL, jobID)
 	jsonStr := fmt.Sprintf(`{
 		"target-directory" : "%s",
-		"cancel-job" : %v
-	}`, dir, cancel)
+		"cancel-job" : %v,
+		"formatType" : "%s"
+	}`, dir, cancel, formatType)
 	resp, err := c.httpClient.Post(url, "application/json", strings.NewReader(jsonStr))
 	if err != nil {
 		return nil, err

--- a/internal/flink/client_test.go
+++ b/internal/flink/client_test.go
@@ -76,3 +76,61 @@ func TestTriggerSavepointPayload(t *testing.T) {
 		})
 	}
 }
+
+func TestStopJobWithSavepointPayload(t *testing.T) {
+	tests := []struct {
+		name         string
+		formatType   string
+		expectedBody map[string]interface{}
+	}{
+		{
+			name:       "with formatType NATIVE",
+			formatType: "NATIVE",
+			expectedBody: map[string]interface{}{
+				"targetDirectory": "/savepoints",
+				"drain":           false,
+				"formatType":      "NATIVE",
+			},
+		},
+		{
+			name:       "with formatType CANONICAL",
+			formatType: "CANONICAL",
+			expectedBody: map[string]interface{}{
+				"targetDirectory": "/savepoints",
+				"drain":           false,
+				"formatType":      "CANONICAL",
+			},
+		},
+		{
+			name:       "without formatType",
+			formatType: "",
+			expectedBody: map[string]interface{}{
+				"targetDirectory": "/savepoints",
+				"drain":           false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedBody map[string]interface{}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, r.URL.Path, "/jobs/job-1/stop")
+				body, err := io.ReadAll(r.Body)
+				assert.NilError(t, err)
+				assert.NilError(t, json.Unmarshal(body, &capturedBody))
+				w.Header().Set("Content-Type", "application/json")
+				_, err = w.Write([]byte(`{"request-id": "abc123"}`))
+				assert.NilError(t, err)
+			}))
+			defer server.Close()
+
+			client := NewClient(logr.Discard(), server.Client())
+			triggerID, err := client.StopJobWithSavepoint(server.URL, "job-1", "/savepoints", tt.formatType)
+
+			assert.NilError(t, err)
+			assert.Equal(t, triggerID.RequestID, "abc123")
+			assert.DeepEqual(t, capturedBody, tt.expectedBody)
+		})
+	}
+}

--- a/internal/flink/client_test.go
+++ b/internal/flink/client_test.go
@@ -1,0 +1,78 @@
+package flink
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"gotest.tools/v3/assert"
+)
+
+func TestTriggerSavepointPayload(t *testing.T) {
+	tests := []struct {
+		name         string
+		cancel       bool
+		formatType   string
+		expectedBody map[string]interface{}
+	}{
+		{
+			name:       "with formatType NATIVE",
+			formatType: "NATIVE",
+			expectedBody: map[string]interface{}{
+				"target-directory": "/savepoints",
+				"cancel-job":       false,
+				"formatType":       "NATIVE",
+			},
+		},
+		{
+			name:       "with formatType CANONICAL",
+			formatType: "CANONICAL",
+			expectedBody: map[string]interface{}{
+				"target-directory": "/savepoints",
+				"cancel-job":       false,
+				"formatType":       "CANONICAL",
+			},
+		},
+		{
+			name:       "without formatType",
+			formatType: "",
+			expectedBody: map[string]interface{}{
+				"target-directory": "/savepoints",
+				"cancel-job":       false,
+			},
+		},
+		{
+			name:       "cancel with formatType",
+			cancel:     true,
+			formatType: "NATIVE",
+			expectedBody: map[string]interface{}{
+				"target-directory": "/savepoints",
+				"cancel-job":       true,
+				"formatType":       "NATIVE",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedBody map[string]interface{}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				json.Unmarshal(body, &capturedBody)
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(`{"request-id": "abc123"}`))
+			}))
+			defer server.Close()
+
+			client := NewClient(logr.Discard(), server.Client())
+			triggerID, err := client.TriggerSavepoint(server.URL, "job-1", "/savepoints", tt.cancel, tt.formatType)
+
+			assert.NilError(t, err)
+			assert.Equal(t, triggerID.RequestID, "abc123")
+			assert.DeepEqual(t, capturedBody, tt.expectedBody)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Flink supports two savepoint formats: `CANONICAL` and `NATIVE`. This PR allows you to control which format is used by setting the `savepointFormatType` property in the job spec. If not specified, Flink uses the canonical format by default.

## Test plan

- Tested manually on a local minikube environment.