### PR TITLE
Allow cancelling job without savepoint

### DIFF
--- a/apis/flinkcluster/v1beta1/flinkcluster_types.go
+++ b/apis/flinkcluster/v1beta1/flinkcluster_types.go
@@ -112,8 +112,9 @@ const (
 	ControlAnnotation = "flinkclusters.flinkoperator.k8s.io/user-control"
 
 	// control name
-	ControlNameSavepoint = "savepoint"
-	ControlNameJobCancel = "job-cancel"
+	ControlNameSavepoint                 = "savepoint"
+	ControlNameJobCancel                 = "job-cancel"
+	ControlNameJobCancelWithoutSavepoint = "job-cancel-without-savepoint"
 
 	// control state
 	ControlStateRequested  = "Requested"

--- a/apis/flinkcluster/v1beta1/flinkcluster_validate.go
+++ b/apis/flinkcluster/v1beta1/flinkcluster_validate.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	InvalidControlAnnMsg           = "invalid value for annotation key: %v, value: %v, available values: savepoint, job-cancel"
+	InvalidControlAnnMsg           = "invalid value for annotation key: %v, value: %v, available values: savepoint, job-cancel, job-cancel-without-savepoint"
 	InvalidJobStateForJobCancelMsg = "job-cancel is not allowed because job is not started yet or already terminated, annotation: %v"
 	InvalidJobStateForSavepointMsg = "savepoint is not allowed because job is not started yet or already stopped, annotation: %v"
 	InvalidSavepointDirMsg         = "savepoint is not allowed without spec.job.savepointsDir, annotation: %v"
@@ -136,10 +136,10 @@ func (v *Validator) checkControlAnnotations(old *FlinkCluster, new *FlinkCluster
 			return fmt.Errorf(ControlChangeWarnMsg, ControlAnnotation)
 		}
 		switch newUserControl {
-		case ControlNameJobCancel:
+		case ControlNameJobCancel, ControlNameJobCancelWithoutSavepoint:
 			var job = old.Status.Components.Job
 			if old.Spec.Job == nil {
-				return fmt.Errorf(SessionClusterWarnMsg, ControlNameJobCancel, ControlAnnotation)
+				return fmt.Errorf(SessionClusterWarnMsg, newUserControl, ControlAnnotation)
 			} else if job == nil || job.IsTerminated(old.Spec.Job) {
 				return errors.NewResourceExpired(fmt.Sprintf(InvalidJobStateForJobCancelMsg, ControlAnnotation))
 			}

--- a/apis/flinkcluster/v1beta1/flinkcluster_validate_test.go
+++ b/apis/flinkcluster/v1beta1/flinkcluster_validate_test.go
@@ -705,7 +705,7 @@ func TestUserControlInvalid(t *testing.T) {
 	}
 	var oldCluster = FlinkCluster{}
 	var err = validator.ValidateUpdate(&oldCluster, &newCluster)
-	var expectedErr = "invalid value for annotation key: flinkclusters.flinkoperator.k8s.io/user-control, value: cancel, available values: savepoint, job-cancel"
+	var expectedErr = "invalid value for annotation key: flinkclusters.flinkoperator.k8s.io/user-control, value: cancel, available values: savepoint, job-cancel, job-cancel-without-savepoint"
 	assert.Equal(t, err.Error(), expectedErr)
 }
 

--- a/controllers/flinkcluster/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler.go
@@ -552,7 +552,7 @@ func (reconciler *ClusterReconciler) reconcileJob(ctx context.Context) (ctrl.Res
 				newControlStatus = getControlStatus(userControl, v1beta1.ControlStateInProgress)
 			}
 
-			takeSavepoint := userControl != v1beta1.ControlNameJobCancelWithoutSavepoint
+			takeSavepoint := cancelShouldTakeSavepoint(observed.cluster)
 			log.Info("Stopping job", "jobID", jobID)
 			if err := reconciler.cancelRunningJobs(ctx, takeSavepoint); err != nil {
 				return requeueResult, err

--- a/controllers/flinkcluster/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler.go
@@ -438,12 +438,13 @@ func (reconciler *ClusterReconciler) reconcileJob(ctx context.Context) (ctrl.Res
 	if wasJobCancelRequested(observed.cluster.Status.Control) {
 		log.Info("Force tearing down the job")
 		userControl := getNewControlRequest(observed.cluster)
-		if userControl == v1beta1.ControlNameJobCancel {
+		if userControl == v1beta1.ControlNameJobCancel || userControl == v1beta1.ControlNameJobCancelWithoutSavepoint {
 			newControlStatus = getControlStatus(userControl, v1beta1.ControlStateInProgress)
 		}
 		// cancel all running jobs
 		if job.IsActive() {
-			if err := reconciler.cancelRunningJobs(ctx, true /* takeSavepoint */); err != nil && !errors.IsResourceExpired(err) {
+			takeSavepoint := observed.cluster.Status.Control.Name != v1beta1.ControlNameJobCancelWithoutSavepoint
+			if err := reconciler.cancelRunningJobs(ctx, takeSavepoint); err != nil && !errors.IsResourceExpired(err) {
 				return requeueResult, err
 			}
 		}
@@ -547,12 +548,13 @@ func (reconciler *ClusterReconciler) reconcileJob(ctx context.Context) (ctrl.Res
 	if desiredJob == nil && (!job.IsStopped() || observedSubmitter != nil) {
 		if job.IsActive() {
 			userControl := getNewControlRequest(observed.cluster)
-			if userControl == v1beta1.ControlNameJobCancel {
+			if userControl == v1beta1.ControlNameJobCancel || userControl == v1beta1.ControlNameJobCancelWithoutSavepoint {
 				newControlStatus = getControlStatus(userControl, v1beta1.ControlStateInProgress)
 			}
 
+			takeSavepoint := userControl != v1beta1.ControlNameJobCancelWithoutSavepoint
 			log.Info("Stopping job", "jobID", jobID)
-			if err := reconciler.cancelRunningJobs(ctx, true /* takeSavepoint */); err != nil {
+			if err := reconciler.cancelRunningJobs(ctx, takeSavepoint); err != nil {
 				return requeueResult, err
 			}
 		} else if job.IsStopped() && observedSubmitter != nil {

--- a/controllers/flinkcluster/flinkcluster_updater.go
+++ b/controllers/flinkcluster/flinkcluster_updater.go
@@ -1083,6 +1083,14 @@ func deriveControlStatus(
 				c.Message = "Aborted job cancellation: job is stopped already."
 				c.State = v1beta1.ControlStateFailed
 			}
+		case v1beta1.ControlNameJobCancelWithoutSavepoint:
+			switch {
+			case newJob.State == v1beta1.JobStateCancelled:
+				c.State = v1beta1.ControlStateSucceeded
+			case newJob.IsStopped():
+				c.Message = "Aborted job cancellation: job is stopped already."
+				c.State = v1beta1.ControlStateFailed
+			}
 		case v1beta1.ControlNameSavepoint:
 			if newSavepoint == nil {
 				c.Message = "Aborted: savepoint not defined"

--- a/controllers/flinkcluster/flinkcluster_util.go
+++ b/controllers/flinkcluster/flinkcluster_util.go
@@ -156,6 +156,7 @@ func shouldStopJob(cluster *v1beta1.FlinkCluster) bool {
 	var userControl = cluster.Annotations[v1beta1.ControlAnnotation]
 	var cancelRequested = cluster.Spec.Job.CancelRequested
 	return userControl == v1beta1.ControlNameJobCancel ||
+		userControl == v1beta1.ControlNameJobCancelWithoutSavepoint ||
 		(cancelRequested != nil && *cancelRequested)
 }
 
@@ -577,7 +578,9 @@ func IsApplicationModeCluster(cluster *v1beta1.FlinkCluster) bool {
 
 // checks if job-cancel was requested
 func wasJobCancelRequested(controlStatus *v1beta1.FlinkClusterControlStatus) bool {
-	return controlStatus != nil && controlStatus.Name == v1beta1.ControlNameJobCancel
+	return controlStatus != nil &&
+		(controlStatus.Name == v1beta1.ControlNameJobCancel ||
+			controlStatus.Name == v1beta1.ControlNameJobCancelWithoutSavepoint)
 }
 
 func GenJobId(cluster *v1beta1.FlinkCluster) (string, error) {

--- a/controllers/flinkcluster/flinkcluster_util.go
+++ b/controllers/flinkcluster/flinkcluster_util.go
@@ -151,6 +151,14 @@ func canTakeSavepoint(cluster *v1beta1.FlinkCluster) bool {
 		(savepointStatus == nil || savepointStatus.State != v1beta1.SavepointStateInProgress)
 }
 
+// cancelShouldTakeSavepoint returns false when the user requested cancellation
+// without a savepoint. It reads the annotation directly so the intent is
+// preserved across reconcile cycles while the control is InProgress
+// (getNewControlRequest returns "" during that window).
+func cancelShouldTakeSavepoint(cluster *v1beta1.FlinkCluster) bool {
+	return cluster.Annotations[v1beta1.ControlAnnotation] != v1beta1.ControlNameJobCancelWithoutSavepoint
+}
+
 // Checks if the job should be stopped because a job-cancel was requested
 func shouldStopJob(cluster *v1beta1.FlinkCluster) bool {
 	var userControl = cluster.Annotations[v1beta1.ControlAnnotation]

--- a/controllers/flinkcluster/flinkcluster_util_test.go
+++ b/controllers/flinkcluster/flinkcluster_util_test.go
@@ -407,3 +407,50 @@ func TestGetFlinkJobSubmitLog(t *testing.T) {
 	submit = getFlinkJobSubmitLogFromString("")
 	assert.Equal(t, submit.jobID, "")
 }
+
+func TestCancelShouldTakeSavepoint(t *testing.T) {
+	inProgress := &v1beta1.FlinkClusterControlStatus{
+		Name:  v1beta1.ControlNameJobCancelWithoutSavepoint,
+		State: v1beta1.ControlStateInProgress,
+	}
+
+	cases := []struct {
+		name       string
+		annotation string
+		control    *v1beta1.FlinkClusterControlStatus
+		want       bool
+	}{
+		{
+			name:       "regular cancel takes savepoint",
+			annotation: v1beta1.ControlNameJobCancel,
+			want:       true,
+		},
+		{
+			name:       "cancel-without-savepoint first reconcile",
+			annotation: v1beta1.ControlNameJobCancelWithoutSavepoint,
+			want:       false,
+		},
+		{
+			// Regression: getNewControlRequest returns "" while InProgress,
+			// so reading it instead of the annotation would wrongly return true.
+			name:       "cancel-without-savepoint in-progress reconcile",
+			annotation: v1beta1.ControlNameJobCancelWithoutSavepoint,
+			control:    inProgress,
+			want:       false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster := &v1beta1.FlinkCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						v1beta1.ControlAnnotation: tc.annotation,
+					},
+				},
+				Status: v1beta1.FlinkClusterStatus{Control: tc.control},
+			}
+			assert.Equal(t, cancelShouldTakeSavepoint(cluster), tc.want)
+		})
+	}
+}

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -348,10 +348,18 @@ make deploy
 
 If you want to cancel a running Flink job, attach control annotation to your FlinkCluster's metadata:
 
-```
+```yaml
 metadata:
   annotations:
     flinkclusters.flinkoperator.k8s.io/user-control: job-cancel
+```
+
+or
+
+```yaml
+metadata:
+  annotations:
+    flinkclusters.flinkoperator.k8s.io/user-control: job-cancel-without-savepoint
 ```
 
 You can attach the annotation:
@@ -363,6 +371,9 @@ kubectl annotate flinkclusters <CLUSTER-NAME> flinkclusters.flinkoperator.k8s.io
 When canceling, all Pods that make up the Flink cluster are basically terminated.
 If you want to leave the cluster, configure spec.job.cleanupPolicy.afterJobCancelled
 according to the [FlinkCluster Custom Resource Definition](./crd.md).
+
+In streaming mode, if `savepointsDir` is specified, `job-cancel` stops the job with a
+savepoint, `job-cancel-without-savepoint`, cancels the it without one.
 
 When job cancellation is finished, the control annotation disappears and the progress
 can be checked in FlinkCluster status:


### PR DESCRIPTION
# Summary

When `flinkclusters.flinkoperator.k8s.io/user-control` is set to `job-cancel`, the job is stopped with a savepoint. However, sometimes, mainly during testing phase, we want to stop the job without taking a savepoint. To this end, I propose to add `flinkclusters.flinkoperator.k8s.io/user-control=job-cancel-without-savepoint`.