### PR TITLE
chore: compact operator state logs

### DIFF
--- a/apis/flinkcluster/v1beta1/flinkcluster_webhook.go
+++ b/apis/flinkcluster/v1beta1/flinkcluster_webhook.go
@@ -29,6 +29,33 @@ import (
 
 var log = logf.Log.WithName("webhook")
 
+func flinkClusterLogSummary(cluster *FlinkCluster) any {
+	if cluster == nil {
+		return "nil"
+	}
+
+	summary := map[string]any{
+		"namespace":       cluster.Namespace,
+		"name":            cluster.Name,
+		"generation":      cluster.Generation,
+		"resourceVersion": cluster.ResourceVersion,
+		"flinkVersion":    cluster.Spec.FlinkVersion,
+		"image":           cluster.Spec.Image.Name,
+		"state":           cluster.Status.State,
+	}
+	if cluster.Spec.Job != nil {
+		summary["jobClass"] = cluster.Spec.Job.ClassName
+	}
+	if cluster.Spec.TaskManager != nil && cluster.Spec.TaskManager.Replicas != nil {
+		summary["taskManagerReplicas"] = *cluster.Spec.TaskManager.Replicas
+	}
+	if cluster.Status.Components.Job != nil {
+		summary["jobState"] = cluster.Status.Components.Job.State
+		summary["jobID"] = cluster.Status.Components.Job.ID
+	}
+	return summary
+}
+
 // flinkClusterDefaulter implements admission.CustomDefaulter for FlinkCluster.
 type flinkClusterDefaulter struct{}
 
@@ -55,9 +82,9 @@ The meaning of each marker can be found [here](/reference/markers/webhook.md).
 
 // Default implements admission.Defaulter[*FlinkCluster].
 func (d *flinkClusterDefaulter) Default(ctx context.Context, cluster *FlinkCluster) error {
-	log.Info("default", "name", cluster.Name, "original", *cluster)
+	log.Info("default", "cluster", flinkClusterLogSummary(cluster), "phase", "original")
 	_SetDefault(cluster)
-	log.Info("default", "name", cluster.Name, "augmented", *cluster)
+	log.Info("default", "cluster", flinkClusterLogSummary(cluster), "phase", "augmented")
 	return nil
 }
 

--- a/apis/flinkcluster/v1beta1/flinkcluster_webhook_logging_test.go
+++ b/apis/flinkcluster/v1beta1/flinkcluster_webhook_logging_test.go
@@ -1,0 +1,46 @@
+package v1beta1
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestFlinkClusterLogSummaryDoesNotIncludeFullObject(t *testing.T) {
+	bigValue := strings.Repeat("x", 20_000)
+	cluster := &FlinkCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "test-namespace",
+			Annotations: map[string]string{
+				"large": bigValue,
+			},
+		},
+		Spec: FlinkClusterSpec{
+			FlinkVersion: "1.20.0",
+			Image: ImageSpec{
+				Name: "flink:1.20.0",
+			},
+			LogConfig: map[string]string{
+				"log4j-console.properties": bigValue,
+			},
+		},
+	}
+
+	payload, err := json.Marshal(flinkClusterLogSummary(cluster))
+	if err != nil {
+		t.Fatalf("failed to marshal summary: %v", err)
+	}
+	payloadString := string(payload)
+	if strings.Contains(payloadString, bigValue[:100]) {
+		t.Fatalf("summary leaked full object content")
+	}
+	if len(payload) > 1_000 {
+		t.Fatalf("summary is unexpectedly large: %d bytes", len(payload))
+	}
+	if !strings.Contains(payloadString, "test-cluster") {
+		t.Fatalf("summary lost object identity: %s", payloadString)
+	}
+}

--- a/controllers/flinkcluster/flinkcluster_controller.go
+++ b/controllers/flinkcluster/flinkcluster_controller.go
@@ -195,55 +195,10 @@ func (handler *FlinkClusterHandler) reconcile(ctx context.Context,
 	log.Info("---------- 3. Compute the desired state ----------")
 
 	*desired = *getDesiredClusterState(observed)
-	if desired.ConfigMap != nil {
-		log = log.WithValues("ConfigMap", *desired.ConfigMap)
-	} else {
-		log = log.WithValues("ConfigMap", "nil")
+	log.Info("Desired state", "state", logDesiredClusterStateSummary(desired))
+	if debugLog := log.V(1); debugLog.Enabled() {
+		debugLog.Info("Desired state full", "state", logDesiredClusterStateFull(desired))
 	}
-	if desired.PodDisruptionBudget != nil {
-		log = log.WithValues("PodDisruptionBudget", *desired.PodDisruptionBudget)
-	} else {
-		log = log.WithValues("PodDisruptionBudget", "nil")
-	}
-	if desired.TmService != nil {
-		log = log.WithValues("TaskManager Service", *desired.TmService)
-	} else {
-		log = log.WithValues("TaskManager Service", "nil")
-	}
-	if desired.JmStatefulSet != nil {
-		log = log.WithValues("JobManager StatefulSet", *desired.JmStatefulSet)
-	} else {
-		log = log.WithValues("JobManager StatefulSet", "nil")
-	}
-	if desired.JmService != nil {
-		log = log.WithValues("JobManager service", *desired.JmService)
-	} else {
-		log = log.WithValues("JobManager service", "nil")
-	}
-	if desired.JmIngress != nil {
-		log = log.WithValues("JobManager ingress", *desired.JmIngress)
-	} else {
-		log = log.WithValues("JobManager ingress", "nil")
-	}
-	if desired.TmStatefulSet != nil {
-		log = log.WithValues("TaskManager StatefulSet", *desired.TmStatefulSet)
-	} else if desired.TmDeployment != nil {
-		log = log.WithValues("TaskManager Deployment", *desired.TmDeployment)
-	} else {
-		log = log.WithValues("TaskManager", "nil")
-	}
-	if desired.HorizontalPodAutoscaler != nil {
-		log = log.WithValues("HorizontalPodAutoscaler", *desired.HorizontalPodAutoscaler)
-	} else {
-		log = log.WithValues("HorizontalPodAutoscaler", "nil")
-	}
-
-	if desired.Job != nil {
-		log = log.WithValues("Job", *desired.Job)
-	} else {
-		log = log.WithValues("Job", "nil")
-	}
-	log.Info("Desired state")
 
 	log.Info("---------- 4. Take actions ----------")
 

--- a/controllers/flinkcluster/flinkcluster_logging.go
+++ b/controllers/flinkcluster/flinkcluster_logging.go
@@ -1,0 +1,419 @@
+package flinkcluster
+
+import (
+	"reflect"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1beta1 "github.com/spotify/flink-on-k8s-operator/apis/flinkcluster/v1beta1"
+	flink "github.com/spotify/flink-on-k8s-operator/internal/flink"
+	"github.com/spotify/flink-on-k8s-operator/internal/model"
+)
+
+const (
+	logNilValue = "nil"
+)
+
+func logObjectSummary(obj client.Object) any {
+	if isNilClientObject(obj) {
+		return logNilValue
+	}
+
+	summary := map[string]any{
+		"kind":      logObjectKind(obj),
+		"namespace": obj.GetNamespace(),
+		"name":      obj.GetName(),
+	}
+	if apiVersion := logObjectAPIVersion(obj); apiVersion != "" {
+		summary["apiVersion"] = apiVersion
+	}
+	if generation := obj.GetGeneration(); generation != 0 {
+		summary["generation"] = generation
+	}
+	if resourceVersion := obj.GetResourceVersion(); resourceVersion != "" {
+		summary["resourceVersion"] = resourceVersion
+	}
+	return summary
+}
+
+func logFlinkClusterSummary(cluster *v1beta1.FlinkCluster) any {
+	if cluster == nil {
+		return logNilValue
+	}
+
+	summary := map[string]any{
+		"kind":            logObjectKind(cluster),
+		"namespace":       cluster.Namespace,
+		"name":            cluster.Name,
+		"generation":      cluster.Generation,
+		"resourceVersion": cluster.ResourceVersion,
+		"flinkVersion":    cluster.Spec.FlinkVersion,
+		"image":           cluster.Spec.Image.Name,
+		"state":           cluster.Status.State,
+		"revision":        logRevisionStatusSummary(cluster.Status.Revision),
+	}
+	if cluster.Spec.Job != nil {
+		summary["jobClass"] = cluster.Spec.Job.ClassName
+	}
+	if cluster.Spec.TaskManager != nil && cluster.Spec.TaskManager.Replicas != nil {
+		summary["taskManagerReplicas"] = *cluster.Spec.TaskManager.Replicas
+	}
+	if cluster.Status.Components.Job != nil {
+		summary["job"] = logJobStatusSummary(cluster.Status.Components.Job)
+	}
+	if cluster.Status.Savepoint != nil {
+		summary["savepoint"] = logSavepointStatusSummary(cluster.Status.Savepoint)
+	}
+	if cluster.Status.Control != nil {
+		summary["control"] = logControlStatusSummary(cluster.Status.Control)
+	}
+	return summary
+}
+
+func logObservedClusterStateSummary(observed *ObservedClusterState) map[string]any {
+	if observed == nil {
+		return map[string]any{"cluster": logNilValue}
+	}
+
+	summary := map[string]any{
+		"cluster":                 logFlinkClusterSummary(observed.cluster),
+		"controllerRevisions":     logControllerRevisionsSummary(observed.revisions),
+		"configMap":               logObjectSummary(observed.configMap),
+		"podDisruptionBudget":     logObjectSummary(observed.podDisruptionBudget),
+		"jobManagerStatefulSet":   logObjectSummary(observed.jmStatefulSet),
+		"jobManagerService":       logObjectSummary(observed.jmService),
+		"jobManagerIngress":       logObjectSummary(observed.jmIngress),
+		"taskManagerStatefulSet":  logObjectSummary(observed.tmStatefulSet),
+		"taskManagerDeployment":   logObjectSummary(observed.tmDeployment),
+		"taskManagerService":      logObjectSummary(observed.tmService),
+		"horizontalPodAutoscaler": logObjectSummary(observed.horizontalPodAutoscaler),
+		"flinkJob":                logFlinkJobSummary(observed.flinkJob.status),
+		"flinkJobCount":           logFlinkJobCount(observed.flinkJob.list),
+		"flinkJobExceptionCount":  logFlinkJobExceptionCount(observed.flinkJob.exceptions),
+		"unexpectedFlinkJobCount": len(observed.flinkJob.unexpected),
+		"jobSubmitter":            logObjectSummary(observed.flinkJobSubmitter.job),
+		"jobSubmitterPod":         logObjectSummary(observed.flinkJobSubmitter.pod),
+		"jobSubmitterLog":         logSubmitterLogSummary(observed.flinkJobSubmitter.log),
+		"savepoint":               logFlinkSavepointSummary(observed.savepoint.status, observed.savepoint.error),
+	}
+	if observed.persistentVolumeClaims != nil {
+		summary["persistentVolumeClaimCount"] = len(observed.persistentVolumeClaims.Items)
+	} else {
+		summary["persistentVolumeClaimCount"] = logNilValue
+	}
+	return summary
+}
+
+func logDesiredClusterStateSummary(desired *model.DesiredClusterState) map[string]any {
+	if desired == nil {
+		return map[string]any{"components": logNilValue}
+	}
+
+	return map[string]any{
+		"configMap":               logObjectSummary(desired.ConfigMap),
+		"podDisruptionBudget":     logObjectSummary(desired.PodDisruptionBudget),
+		"jobManagerStatefulSet":   logObjectSummary(desired.JmStatefulSet),
+		"jobManagerService":       logObjectSummary(desired.JmService),
+		"jobManagerIngress":       logObjectSummary(desired.JmIngress),
+		"taskManagerStatefulSet":  logObjectSummary(desired.TmStatefulSet),
+		"taskManagerDeployment":   logObjectSummary(desired.TmDeployment),
+		"taskManagerService":      logObjectSummary(desired.TmService),
+		"horizontalPodAutoscaler": logObjectSummary(desired.HorizontalPodAutoscaler),
+		"job":                     logObjectSummary(desired.Job),
+	}
+}
+
+func logObservedClusterStateFull(observed *ObservedClusterState) map[string]any {
+	if observed == nil {
+		return map[string]any{"cluster": logNilValue}
+	}
+
+	summary := map[string]any{
+		"cluster":                 logFullObject(observed.cluster),
+		"controllerRevisions":     observed.revisions,
+		"configMap":               logFullObject(observed.configMap),
+		"podDisruptionBudget":     logFullObject(observed.podDisruptionBudget),
+		"jobManagerStatefulSet":   logFullObject(observed.jmStatefulSet),
+		"jobManagerService":       logFullObject(observed.jmService),
+		"jobManagerIngress":       logFullObject(observed.jmIngress),
+		"taskManagerStatefulSet":  logFullObject(observed.tmStatefulSet),
+		"taskManagerDeployment":   logFullObject(observed.tmDeployment),
+		"taskManagerService":      logFullObject(observed.tmService),
+		"horizontalPodAutoscaler": logFullObject(observed.horizontalPodAutoscaler),
+		"savepoint":               logFullObject(observed.savepoint.status),
+	}
+	if observed.persistentVolumeClaims != nil {
+		summary["persistentVolumeClaims"] = observed.persistentVolumeClaims.Items
+	} else {
+		summary["persistentVolumeClaims"] = logNilValue
+	}
+	return summary
+}
+
+func logDesiredClusterStateFull(desired *model.DesiredClusterState) map[string]any {
+	if desired == nil {
+		return map[string]any{"components": logNilValue}
+	}
+
+	return map[string]any{
+		"configMap":               logFullObject(desired.ConfigMap),
+		"podDisruptionBudget":     logFullObject(desired.PodDisruptionBudget),
+		"jobManagerStatefulSet":   logFullObject(desired.JmStatefulSet),
+		"jobManagerService":       logFullObject(desired.JmService),
+		"jobManagerIngress":       logFullObject(desired.JmIngress),
+		"taskManagerStatefulSet":  logFullObject(desired.TmStatefulSet),
+		"taskManagerDeployment":   logFullObject(desired.TmDeployment),
+		"taskManagerService":      logFullObject(desired.TmService),
+		"horizontalPodAutoscaler": logFullObject(desired.HorizontalPodAutoscaler),
+		"job":                     logFullObject(desired.Job),
+	}
+}
+
+func logFullObject(obj any) any {
+	if obj == nil {
+		return logNilValue
+	}
+
+	value := reflect.ValueOf(obj)
+	if value.Kind() == reflect.Ptr {
+		if value.IsNil() {
+			return logNilValue
+		}
+		return value.Elem().Interface()
+	}
+	return obj
+}
+
+func logClusterStatusSummary(status *v1beta1.FlinkClusterStatus) any {
+	if status == nil {
+		return logNilValue
+	}
+
+	return map[string]any{
+		"state":             status.State,
+		"configMap":         logConfigMapStatusSummary(status.Components.ConfigMap),
+		"jobManager":        logJobManagerStatusSummary(status.Components.JobManager),
+		"jobManagerService": logJobManagerServiceStatusSummary(status.Components.JobManagerService),
+		"jobManagerIngress": logJobManagerIngressStatusSummary(status.Components.JobManagerIngress),
+		"taskManager":       logTaskManagerStatusSummary(status.Components.TaskManager),
+		"job":               logJobStatusSummary(status.Components.Job),
+		"control":           logControlStatusSummary(status.Control),
+		"savepoint":         logSavepointStatusSummary(status.Savepoint),
+		"revision":          logRevisionStatusSummary(status.Revision),
+	}
+}
+
+func logConfigMapStatusSummary(status *v1beta1.ConfigMapStatus) any {
+	if status == nil {
+		return logNilValue
+	}
+	return map[string]any{
+		"name":  status.Name,
+		"state": status.State,
+	}
+}
+
+func logJobManagerStatusSummary(status *v1beta1.JobManagerStatus) any {
+	if status == nil {
+		return logNilValue
+	}
+	return map[string]any{
+		"name":          status.Name,
+		"state":         status.State,
+		"replicas":      status.Replicas,
+		"readyReplicas": status.ReadyReplicas,
+		"ready":         status.Ready,
+	}
+}
+
+func logJobManagerServiceStatusSummary(status v1beta1.JobManagerServiceStatus) any {
+	return map[string]any{
+		"name":  status.Name,
+		"state": status.State,
+	}
+}
+
+func logJobManagerIngressStatusSummary(status *v1beta1.JobManagerIngressStatus) any {
+	if status == nil {
+		return logNilValue
+	}
+	return map[string]any{
+		"name":     status.Name,
+		"state":    status.State,
+		"urlCount": len(status.URLs),
+	}
+}
+
+func logTaskManagerStatusSummary(status *v1beta1.TaskManagerStatus) any {
+	if status == nil {
+		return logNilValue
+	}
+	return map[string]any{
+		"name":          status.Name,
+		"state":         status.State,
+		"replicas":      status.Replicas,
+		"readyReplicas": status.ReadyReplicas,
+		"ready":         status.Ready,
+	}
+}
+
+func logJobStatusSummary(status *v1beta1.JobStatus) any {
+	if status == nil {
+		return logNilValue
+	}
+	return map[string]any{
+		"id":                   status.ID,
+		"name":                 status.Name,
+		"submitterName":        status.SubmitterName,
+		"submitterExitCode":    status.SubmitterExitCode,
+		"state":                status.State,
+		"savepointGeneration":  status.SavepointGeneration,
+		"finalSavepoint":       status.FinalSavepoint,
+		"restartCount":         status.RestartCount,
+		"failureReasonCount":   len(status.FailureReasons),
+		"hasSavepointLocation": status.SavepointLocation != "",
+		"hasFromSavepoint":     status.FromSavepoint != "",
+	}
+}
+
+func logControlStatusSummary(status *v1beta1.FlinkClusterControlStatus) any {
+	if status == nil {
+		return logNilValue
+	}
+	return map[string]any{
+		"name":        status.Name,
+		"state":       status.State,
+		"detailCount": len(status.Details),
+		"hasMessage":  status.Message != "",
+		"updateTime":  status.UpdateTime,
+	}
+}
+
+func logSavepointStatusSummary(status *v1beta1.SavepointStatus) any {
+	if status == nil {
+		return logNilValue
+	}
+	return map[string]any{
+		"jobID":       status.JobID,
+		"triggerID":   status.TriggerID,
+		"reason":      status.TriggerReason,
+		"state":       status.State,
+		"hasMessage":  status.Message != "",
+		"triggerTime": status.TriggerTime,
+		"updateTime":  status.UpdateTime,
+	}
+}
+
+func logRevisionStatusSummary(status v1beta1.RevisionStatus) map[string]any {
+	return map[string]any{
+		"currentRevision": status.CurrentRevision,
+		"nextRevision":    status.NextRevision,
+	}
+}
+
+func logControllerRevisionsSummary(revisions []*appsv1.ControllerRevision) []map[string]any {
+	summary := make([]map[string]any, 0, len(revisions))
+	for _, revision := range revisions {
+		if revision == nil {
+			continue
+		}
+		summary = append(summary, map[string]any{
+			"name":     revision.Name,
+			"revision": revision.Revision,
+		})
+	}
+	return summary
+}
+
+func logFlinkJobSummary(job *flink.Job) any {
+	if job == nil {
+		return logNilValue
+	}
+	return map[string]any{
+		"id":        job.Id,
+		"name":      job.Name,
+		"state":     job.State,
+		"startTime": job.StartTime,
+		"endTime":   job.EndTime,
+		"duration":  job.Duration,
+	}
+}
+
+func logFlinkJobCount(jobs *flink.JobsOverview) any {
+	if jobs == nil {
+		return logNilValue
+	}
+	return len(jobs.Jobs)
+}
+
+func logFlinkJobExceptionCount(exceptions *flink.JobExceptions) any {
+	if exceptions == nil {
+		return logNilValue
+	}
+	return len(exceptions.Exceptions)
+}
+
+func logSubmitterLogSummary(submitterLog *SubmitterLog) any {
+	if submitterLog == nil {
+		return logNilValue
+	}
+	return map[string]any{
+		"jobID":      submitterLog.jobID,
+		"hasMessage": submitterLog.message != "",
+	}
+}
+
+func logFlinkSavepointSummary(status *flink.SavepointStatus, err error) any {
+	if status == nil && err == nil {
+		return logNilValue
+	}
+
+	summary := map[string]any{}
+	if status != nil {
+		summary["jobID"] = status.JobID
+		summary["triggerID"] = status.TriggerID
+		summary["completed"] = status.Completed
+		summary["hasLocation"] = status.Location != ""
+	}
+	if err != nil {
+		summary["error"] = err.Error()
+	}
+	return summary
+}
+
+func logObjectKind(obj client.Object) string {
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	if gvk.Kind != "" {
+		return gvk.Kind
+	}
+
+	objType := reflect.TypeOf(obj)
+	for objType.Kind() == reflect.Ptr {
+		objType = objType.Elem()
+	}
+	return objType.Name()
+}
+
+func logObjectAPIVersion(obj client.Object) string {
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	if gvk == (schema.GroupVersionKind{}) {
+		return ""
+	}
+	return gvk.GroupVersion().String()
+}
+
+func isNilClientObject(obj client.Object) bool {
+	if obj == nil {
+		return true
+	}
+
+	value := reflect.ValueOf(obj)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}

--- a/controllers/flinkcluster/flinkcluster_logging_test.go
+++ b/controllers/flinkcluster/flinkcluster_logging_test.go
@@ -1,0 +1,192 @@
+package flinkcluster
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1beta1 "github.com/spotify/flink-on-k8s-operator/apis/flinkcluster/v1beta1"
+	"github.com/spotify/flink-on-k8s-operator/internal/model"
+)
+
+func TestLogObjectSummaryHandlesTypedNil(t *testing.T) {
+	var configMap *corev1.ConfigMap
+	var obj client.Object = configMap
+
+	if got := logObjectSummary(obj); got != logNilValue {
+		t.Fatalf("expected typed nil object to summarize as %q, got %#v", logNilValue, got)
+	}
+}
+
+func TestLogObservedClusterStateSummaryDoesNotIncludeFullObjects(t *testing.T) {
+	bigValue := strings.Repeat("x", 20_000)
+	cluster := &v1beta1.FlinkCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "flinkoperator.k8s.io/v1beta1",
+			Kind:       "FlinkCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-cluster",
+			Namespace:       "test-namespace",
+			Generation:      7,
+			ResourceVersion: "12345",
+			Annotations: map[string]string{
+				"large": bigValue,
+			},
+		},
+		Spec: v1beta1.FlinkClusterSpec{
+			FlinkVersion: "1.20.0",
+			Image: v1beta1.ImageSpec{
+				Name: "flink:1.20.0",
+			},
+			LogConfig: map[string]string{
+				"log4j-console.properties": bigValue,
+			},
+		},
+		Status: v1beta1.FlinkClusterStatus{
+			State: v1beta1.ClusterStateRunning,
+			Components: v1beta1.FlinkClusterComponentsStatus{
+				Job: &v1beta1.JobStatus{
+					ID:    "flink-job-id",
+					State: v1beta1.JobStateRunning,
+				},
+			},
+		},
+	}
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-config",
+			Namespace: "test-namespace",
+		},
+		Data: map[string]string{
+			"large": bigValue,
+		},
+	}
+	observed := &ObservedClusterState{
+		cluster:   cluster,
+		configMap: configMap,
+		revisions: []*appsv1.ControllerRevision{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster-abc-1"},
+				Revision:   1,
+			},
+		},
+	}
+
+	payload := mustMarshalLogSummary(t, logObservedClusterStateSummary(observed))
+	payloadString := string(payload)
+	if strings.Contains(payloadString, bigValue[:100]) {
+		t.Fatalf("summary leaked full object content")
+	}
+	if len(payload) > 5_000 {
+		t.Fatalf("summary is unexpectedly large: %d bytes", len(payload))
+	}
+	if !strings.Contains(payloadString, "test-cluster") {
+		t.Fatalf("summary lost object identity: %s", payloadString)
+	}
+}
+
+func TestLogObservedClusterStateFullIncludesFullObjects(t *testing.T) {
+	bigValue := strings.Repeat("x", 20_000)
+	cluster := &v1beta1.FlinkCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "test-namespace",
+			Annotations: map[string]string{
+				"large": bigValue,
+			},
+		},
+		Spec: v1beta1.FlinkClusterSpec{
+			LogConfig: map[string]string{
+				"log4j-console.properties": bigValue,
+			},
+		},
+	}
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-config",
+			Namespace: "test-namespace",
+		},
+		Data: map[string]string{
+			"large": bigValue,
+		},
+	}
+	observed := &ObservedClusterState{
+		cluster:   cluster,
+		configMap: configMap,
+	}
+
+	payload := mustMarshalLogSummary(t, logObservedClusterStateFull(observed))
+	payloadString := string(payload)
+	if !strings.Contains(payloadString, bigValue[:100]) {
+		t.Fatalf("full observed state log did not include full object content")
+	}
+	if len(payload) < 20_000 {
+		t.Fatalf("full observed state log is unexpectedly small: %d bytes", len(payload))
+	}
+}
+
+func TestLogDesiredClusterStateSummaryDoesNotIncludeFullObjects(t *testing.T) {
+	bigValue := strings.Repeat("x", 20_000)
+	desired := &model.DesiredClusterState{
+		ConfigMap: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-config",
+				Namespace: "test-namespace",
+			},
+			Data: map[string]string{
+				"large": bigValue,
+			},
+		},
+	}
+
+	payload := mustMarshalLogSummary(t, logDesiredClusterStateSummary(desired))
+	payloadString := string(payload)
+	if strings.Contains(payloadString, bigValue[:100]) {
+		t.Fatalf("summary leaked full desired object content")
+	}
+	if len(payload) > 2_000 {
+		t.Fatalf("summary is unexpectedly large: %d bytes", len(payload))
+	}
+	if !strings.Contains(payloadString, "test-config") {
+		t.Fatalf("summary lost desired object identity: %s", payloadString)
+	}
+}
+
+func TestLogDesiredClusterStateFullIncludesFullObjects(t *testing.T) {
+	bigValue := strings.Repeat("x", 20_000)
+	desired := &model.DesiredClusterState{
+		ConfigMap: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-config",
+				Namespace: "test-namespace",
+			},
+			Data: map[string]string{
+				"large": bigValue,
+			},
+		},
+	}
+
+	payload := mustMarshalLogSummary(t, logDesiredClusterStateFull(desired))
+	payloadString := string(payload)
+	if !strings.Contains(payloadString, bigValue[:100]) {
+		t.Fatalf("full desired state log did not include full object content")
+	}
+	if len(payload) < 20_000 {
+		t.Fatalf("full desired state log is unexpectedly small: %d bytes", len(payload))
+	}
+}
+
+func mustMarshalLogSummary(t *testing.T, summary any) []byte {
+	t.Helper()
+	payload, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("failed to marshal summary: %v", err)
+	}
+	return payload
+}

--- a/controllers/flinkcluster/flinkcluster_observer.go
+++ b/controllers/flinkcluster/flinkcluster_observer.go
@@ -18,8 +18,6 @@ package flinkcluster
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -774,74 +772,9 @@ func (observer *ClusterStateObserver) observeObject(ctx context.Context, name st
 
 func (observer *ClusterStateObserver) logObservedState(ctx context.Context, observed *ObservedClusterState) error {
 	log := logr.FromContextOrDiscard(ctx)
-
-	if observed.cluster == nil {
-		log = log.WithValues("cluster", "nil")
-	} else {
-		log = log.WithValues("cluster", *observed.cluster)
-
-		var b strings.Builder
-		for _, cr := range observed.revisions {
-			fmt.Fprintf(&b, "{name: %v, revision: %v},", cr.Name, cr.Revision)
-		}
-		log = log.WithValues("controllerRevisions", fmt.Sprintf("[%v]", b.String()))
-		if observed.configMap != nil {
-			log = log.WithValues("configMap", *observed.configMap)
-		} else {
-			log = log.WithValues("configMap", "nil")
-		}
-		if observed.podDisruptionBudget != nil {
-			log = log.WithValues("podDisruptionBudget", *observed.podDisruptionBudget)
-		} else {
-			log = log.WithValues("podDisruptionBudget", "nil")
-		}
-		if observed.jmStatefulSet != nil {
-			log = log.WithValues("jmStatefulSet", *observed.jmStatefulSet)
-		} else {
-			log = log.WithValues("jmStatefulSet", "nil")
-		}
-		if observed.jmService != nil {
-			log = log.WithValues("jmService", *observed.jmService)
-		} else {
-			log = log.WithValues("jmService", "nil")
-		}
-		if observed.jmIngress != nil {
-			log = log.WithValues("jmIngress", *observed.jmIngress)
-		} else {
-			log = log.WithValues("jmIngress", "nil")
-		}
-		if observed.tmStatefulSet != nil {
-			log = log.WithValues("tmStatefulSet", *observed.tmStatefulSet)
-		} else {
-			log = log.WithValues("tmStatefulSet", "nil")
-		}
-		if observed.tmDeployment != nil {
-			log = log.WithValues("tmDeployment", *observed.tmDeployment)
-		} else {
-			log = log.WithValues("tmDeployment", "nil")
-		}
-		if observed.tmService != nil {
-			log = log.WithValues("tmService", *observed.tmService)
-		} else {
-			log = log.WithValues("tmService", "nil")
-		}
-		if observed.horizontalPodAutoscaler != nil {
-			log = log.WithValues("horizontalPodAutoscaler", *observed.horizontalPodAutoscaler)
-		} else {
-			log = log.WithValues("horizontalPodAutoscaler", "nil")
-		}
-		if observed.savepoint.status != nil {
-			log = log.WithValues("savepoint", *observed.savepoint.status)
-		} else {
-			log = log.WithValues("savepoint", "nil")
-		}
-		if observed.persistentVolumeClaims != nil {
-			log = log.WithValues("persistentVolumeClaims", len(observed.persistentVolumeClaims.Items))
-		} else {
-			log = log.WithValues("persistentVolumeClaims", "nil")
-		}
-
+	log.Info("Observed state", "state", logObservedClusterStateSummary(observed))
+	if debugLog := log.V(1); debugLog.Enabled() {
+		debugLog.Info("Observed state full", "state", logObservedClusterStateFull(observed))
 	}
-	log.Info("Observed state")
 	return nil
 }

--- a/controllers/flinkcluster/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler.go
@@ -252,47 +252,41 @@ func (reconciler *ClusterReconciler) reconcileTaskManagerService(ctx context.Con
 
 func (reconciler *ClusterReconciler) createComponent(
 	ctx context.Context, obj client.Object, component string) error {
-	log := logr.FromContextOrDiscard(ctx).
-		WithValues("component", component).
-		WithValues("object", obj)
+	log := logr.FromContextOrDiscard(ctx).WithValues("component", component)
 
 	if err := reconciler.k8sClient.Create(ctx, obj); err != nil {
-		log.Error(err, "Failed to create")
+		log.Error(err, "Failed to create", "object", logObjectSummary(obj))
 		return err
 	}
 
-	log.Info("Created")
+	log.Info("Created", "object", logObjectSummary(obj))
 	return nil
 }
 
 func (reconciler *ClusterReconciler) updateComponent(ctx context.Context, desired client.Object, component string) error {
-	log := logr.FromContextOrDiscard(ctx).
-		WithValues("component", component).
-		WithValues("object", desired)
+	log := logr.FromContextOrDiscard(ctx).WithValues("component", component)
 	var k8sClient = reconciler.k8sClient
 
 	if err := k8sClient.Update(ctx, desired); err != nil {
-		log.Error(err, "Failed to update component for update")
+		log.Error(err, "Failed to update component for update", "object", logObjectSummary(desired))
 		return err
 	}
 
-	log.Info("Updated")
+	log.Info("Updated", "object", logObjectSummary(desired))
 	return nil
 }
 
 func (reconciler *ClusterReconciler) deleteComponent(
 	ctx context.Context, obj client.Object, component string) error {
-	log := logr.FromContextOrDiscard(ctx).
-		WithValues("component", component).
-		WithValues("object", obj)
+	log := logr.FromContextOrDiscard(ctx).WithValues("component", component)
 	var k8sClient = reconciler.k8sClient
 
 	var err = k8sClient.Delete(ctx, obj)
 	if client.IgnoreNotFound(err) != nil {
-		log.Error(err, "Failed to delete", component, obj)
+		log.Error(err, "Failed to delete", "object", logObjectSummary(obj))
 	}
 
-	log.Info("Deleted")
+	log.Info("Deleted", "object", logObjectSummary(obj))
 	return nil
 }
 
@@ -580,7 +574,7 @@ func (reconciler *ClusterReconciler) createJob(ctx context.Context, job *batchv1
 	log := logr.FromContextOrDiscard(ctx)
 	var k8sClient = reconciler.k8sClient
 
-	log.Info("Creating job submitter", "resource", *job)
+	log.Info("Creating job submitter", "job", logObjectSummary(job))
 	var err = k8sClient.Create(ctx, job)
 	if err != nil {
 		log.Info("Failed to created job submitter", "error", err)
@@ -598,7 +592,7 @@ func (reconciler *ClusterReconciler) deleteJob(ctx context.Context, job *batchv1
 	var deletePolicy = metav1.DeletePropagationBackground
 	var deleteOption = client.DeleteOptions{PropagationPolicy: &deletePolicy}
 
-	log.Info("Deleting job submitter", "job", job)
+	log.Info("Deleting job submitter", "job", logObjectSummary(job))
 	var err = k8sClient.Delete(ctx, job, &deleteOption)
 	err = client.IgnoreNotFound(err)
 	if err != nil {
@@ -647,7 +641,7 @@ func (reconciler *ClusterReconciler) cancelJob(ctx context.Context) error {
 	log := logr.FromContextOrDiscard(ctx)
 	var observedFlinkJob = reconciler.observed.flinkJob.status
 
-	log.Info("Stopping Flink job", "", observedFlinkJob)
+	log.Info("Stopping Flink job", "job", logFlinkJobSummary(observedFlinkJob))
 	var err = reconciler.cancelRunningJobs(ctx, false /* takeSavepoint */)
 	if err != nil {
 		log.Info("Failed to stop Flink job")
@@ -886,7 +880,10 @@ func (reconciler *ClusterReconciler) updateStatus(
 			newStatus.Control = controlStatus
 		}
 		util.SetTimestamp(&newStatus.LastUpdateTime)
-		log.Info("Updating cluster status", "clusterClone", clusterClone, "newStatus", newStatus)
+		log.Info(
+			"Updating cluster status",
+			"cluster", logFlinkClusterSummary(clusterClone),
+			"newStatus", logClusterStatusSummary(newStatus))
 		statusUpdateErr = reconciler.k8sClient.Status().Update(ctx, clusterClone)
 		if statusUpdateErr == nil {
 			return nil


### PR DESCRIPTION
## Summary

- Replace noisy INFO logs that embedded full Kubernetes objects with bounded summaries.
- Preserve key debugging signal: object identity, generations/resource versions, cluster/job state, savepoint/control state, and component counts.
- Add verbosity-1 escape hatches for temporary full state dumps: `Observed state full` and `Desired state full`.
- Compact create/update/delete and webhook default logs so they no longer include full object bodies.

## Validation

- `go test ./controllers/flinkcluster -run 'TestLog'`
- `go test ./apis/flinkcluster/v1beta1 -run 'TestFlinkClusterLogSummary'`
- `go test ./... -run '^$'`

Dev-cluster validation in `flink-dev-gew` with the same streaming test job before/after:

| Metric | Before | After |
|---|---:|---:|
| Log entries | 743 | 670 |
| Total parsed `jsonPayload` bytes | 5,944,668 | 481,323 |
| Largest parsed `jsonPayload` | 49,563 | 2,990 |

Biggest reductions were from `Observed state`, `Desired state`, `Take actions`, `Requeue reconcile request`, and `Created` logs.
