### PR TITLE
Fix application updates after scale revisions

### DIFF
--- a/controllers/flinkcluster/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler.go
@@ -482,7 +482,12 @@ func (reconciler *ClusterReconciler) reconcileJob(ctx context.Context) (ctrl.Res
 		}
 
 		if observedSubmitter != nil {
-			if !isComponentUpdated(observedSubmitter, observed.cluster) {
+			var shouldDeleteForRestart bool
+			if !recorded.Revision.IsUpdateTriggered() && recorded.Revision.CurrentRevision != "" {
+				shouldDeleteForRestart = observedSubmitter.Labels[RevisionNameLabel] ==
+					getCurrentRevisionName(&recorded.Revision)
+			}
+			if !isComponentUpdated(observedSubmitter, observed.cluster) || shouldDeleteForRestart {
 				log.Info("Found old job submitter")
 				err = reconciler.deleteJob(ctx, observedSubmitter)
 				if err != nil {

--- a/controllers/flinkcluster/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler.go
@@ -481,9 +481,8 @@ func (reconciler *ClusterReconciler) reconcileJob(ctx context.Context) (ctrl.Res
 			return requeueResult, err
 		}
 
-		cr := getCurrentRevisionName(&observed.cluster.Status.Revision)
 		if observedSubmitter != nil {
-			if observedSubmitter.Labels[RevisionNameLabel] == cr {
+			if !isComponentUpdated(observedSubmitter, observed.cluster) {
 				log.Info("Found old job submitter")
 				err = reconciler.deleteJob(ctx, observedSubmitter)
 				if err != nil {
@@ -909,29 +908,35 @@ func (reconciler *ClusterReconciler) updateJobDeployStatus(ctx context.Context) 
 	var log = logr.FromContextOrDiscard(ctx)
 	var observedCluster = reconciler.observed.cluster
 	var desiredJobSubmitter = reconciler.desired.Job
-	var err error
+	var newJob *v1beta1.JobStatus
+	var key = types.NamespacedName{Namespace: observedCluster.Namespace, Name: observedCluster.Name}
 
-	var clusterClone = observedCluster.DeepCopy()
-	var newJob = clusterClone.Status.Components.Job
+	var err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		var cluster v1beta1.FlinkCluster
+		if getErr := reconciler.k8sClient.Get(ctx, key, &cluster); getErr != nil {
+			return getErr
+		}
 
-	// Reset running job information.
-	// newJob.ID = ""
-	newJob.StartTime = ""
-	newJob.CompletionTime = nil
+		newJob = cluster.Status.Components.Job
 
-	// Mark as job submitter is deployed.
-	util.SetTimestamp(&newJob.DeployTime)
-	util.SetTimestamp(&clusterClone.Status.LastUpdateTime)
+		// Reset running job information.
+		// newJob.ID = ""
+		newJob.StartTime = ""
+		newJob.CompletionTime = nil
 
-	// Latest savepoint location should be fromSavepoint.
-	var fromSavepoint = getFromSavepoint(desiredJobSubmitter.Spec)
-	newJob.FromSavepoint = fromSavepoint
-	if newJob.SavepointLocation != "" {
-		newJob.SavepointLocation = fromSavepoint
-	}
+		// Mark as job submitter is deployed.
+		util.SetTimestamp(&newJob.DeployTime)
+		util.SetTimestamp(&cluster.Status.LastUpdateTime)
 
-	// Update job status.
-	err = reconciler.k8sClient.Status().Update(ctx, clusterClone)
+		// Latest savepoint location should be fromSavepoint.
+		var fromSavepoint = getFromSavepoint(desiredJobSubmitter.Spec)
+		newJob.FromSavepoint = fromSavepoint
+		if newJob.SavepointLocation != "" {
+			newJob.SavepointLocation = fromSavepoint
+		}
+
+		return reconciler.k8sClient.Status().Update(ctx, &cluster)
+	})
 	if err != nil {
 		log.Error(
 			err, "Failed to update job status for new job submitter", "error", err)

--- a/controllers/flinkcluster/flinkcluster_reconciler_test.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler_test.go
@@ -1,0 +1,159 @@
+package flinkcluster
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	v1beta1 "github.com/spotify/flink-on-k8s-operator/apis/flinkcluster/v1beta1"
+	"github.com/spotify/flink-on-k8s-operator/internal/model"
+	"gotest.tools/v3/assert"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func TestUpdateJobDeployStatusRetriesConflict(t *testing.T) {
+	var scheme = runtime.NewScheme()
+	assert.NilError(t, v1beta1.AddToScheme(scheme))
+
+	var cluster = &v1beta1.FlinkCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "default"},
+		Status: v1beta1.FlinkClusterStatus{
+			Components: v1beta1.FlinkClusterComponentsStatus{
+				Job: &v1beta1.JobStatus{
+					State:             v1beta1.JobStateUpdating,
+					StartTime:         "2026-07-08T14:00:00Z",
+					SavepointLocation: "gs://bucket/old-savepoint",
+				},
+			},
+		},
+	}
+	var fakeClient = fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(cluster).
+		WithObjects(cluster).
+		Build()
+
+	var updateCalls atomic.Int32
+	var interceptedClient = interceptor.NewClient(fakeClient, interceptor.Funcs{
+		SubResourceUpdate: func(
+			ctx context.Context,
+			c client.Client,
+			subResourceName string,
+			obj client.Object,
+			opts ...client.SubResourceUpdateOption,
+		) error {
+			if subResourceName == "status" && updateCalls.Add(1) == 1 {
+				return apierrors.NewConflict(
+					schema.GroupResource{Group: v1beta1.GroupVersion.Group, Resource: "flinkclusters"},
+					obj.GetName(),
+					errors.New("simulated conflict"),
+				)
+			}
+			return c.SubResource(subResourceName).Update(ctx, obj, opts...)
+		},
+	})
+
+	var desiredJob = &batchv1.Job{Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Args: []string{"standalone-job", "--fromSavepoint", "gs://bucket/new-savepoint"},
+		}}},
+	}}}
+	var reconciler = &ClusterReconciler{
+		k8sClient: interceptedClient,
+		observed:  ObservedClusterState{cluster: cluster},
+		desired:   model.DesiredClusterState{Job: desiredJob},
+	}
+
+	assert.NilError(t, reconciler.updateJobDeployStatus(context.Background()))
+	assert.Equal(t, updateCalls.Load(), int32(2))
+
+	var updated v1beta1.FlinkCluster
+	assert.NilError(t, fakeClient.Get(
+		context.Background(),
+		types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace},
+		&updated,
+	))
+	assert.Equal(t, updated.Status.Components.Job.State, v1beta1.JobStateUpdating)
+	assert.Equal(t, updated.Status.Components.Job.StartTime, "")
+	assert.Assert(t, updated.Status.Components.Job.DeployTime != "")
+	assert.Equal(t, updated.Status.Components.Job.FromSavepoint, "gs://bucket/new-savepoint")
+	assert.Equal(t, updated.Status.Components.Job.SavepointLocation, "gs://bucket/new-savepoint")
+}
+
+func TestReconcileJobDeletesSubmitterOlderThanCurrentRevision(t *testing.T) {
+	var scheme = runtime.NewScheme()
+	assert.NilError(t, v1beta1.AddToScheme(scheme))
+	assert.NilError(t, batchv1.AddToScheme(scheme))
+
+	var applicationMode = v1beta1.JobModeApplication
+	var cluster = &v1beta1.FlinkCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "default"},
+		Spec: v1beta1.FlinkClusterSpec{
+			Job: &v1beta1.JobSpec{Mode: &applicationMode},
+		},
+		Status: v1beta1.FlinkClusterStatus{
+			Components: v1beta1.FlinkClusterComponentsStatus{
+				Job: &v1beta1.JobStatus{State: v1beta1.JobStateUpdating, FinalSavepoint: true},
+			},
+			Revision: v1beta1.RevisionStatus{
+				CurrentRevision: "cluster-after-hpa-scale-2",
+				NextRevision:    "cluster-update-3",
+			},
+		},
+	}
+	var oldSubmitter = &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      "cluster-jobmanager",
+		Namespace: cluster.Namespace,
+		Labels: map[string]string{
+			RevisionNameLabel: "cluster-before-hpa-scale",
+		},
+	}}
+	var desiredJob = &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      oldSubmitter.Name,
+			Namespace: oldSubmitter.Namespace,
+			Labels: map[string]string{
+				RevisionNameLabel: "cluster-update",
+			},
+		},
+		Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Args: []string{"standalone-job"}}}},
+		}},
+	}
+	var fakeClient = fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(cluster).
+		WithObjects(cluster, oldSubmitter).
+		Build()
+	var reconciler = &ClusterReconciler{
+		k8sClient: fakeClient,
+		observed: ObservedClusterState{
+			cluster: cluster,
+			flinkJobSubmitter: FlinkJobSubmitter{
+				job: oldSubmitter,
+			},
+		},
+		desired: model.DesiredClusterState{Job: desiredJob},
+	}
+
+	_, err := reconciler.reconcileJob(context.Background())
+	assert.NilError(t, err)
+
+	var submitter batchv1.Job
+	err = fakeClient.Get(
+		context.Background(),
+		types.NamespacedName{Name: oldSubmitter.Name, Namespace: oldSubmitter.Namespace},
+		&submitter,
+	)
+	assert.Assert(t, apierrors.IsNotFound(err))
+}

--- a/controllers/flinkcluster/flinkcluster_reconciler_test.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler_test.go
@@ -157,3 +157,145 @@ func TestReconcileJobDeletesSubmitterOlderThanCurrentRevision(t *testing.T) {
 	)
 	assert.Assert(t, apierrors.IsNotFound(err))
 }
+
+func TestReconcileJobDeletesCompletedSubmitterForDetachedJobRestart(t *testing.T) {
+	var scheme = runtime.NewScheme()
+	assert.NilError(t, v1beta1.AddToScheme(scheme))
+	assert.NilError(t, batchv1.AddToScheme(scheme))
+
+	var detachedMode = v1beta1.JobModeDetached
+	var restartPolicy = v1beta1.JobRestartPolicyFromSavepointOnFailure
+	var cluster = &v1beta1.FlinkCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "default"},
+		Spec: v1beta1.FlinkClusterSpec{
+			Job: &v1beta1.JobSpec{
+				Mode:          &detachedMode,
+				RestartPolicy: &restartPolicy,
+			},
+		},
+		Status: v1beta1.FlinkClusterStatus{
+			Components: v1beta1.FlinkClusterComponentsStatus{
+				Job: &v1beta1.JobStatus{State: v1beta1.JobStateFailed},
+			},
+			Revision: v1beta1.RevisionStatus{
+				CurrentRevision: "cluster-current-1",
+				NextRevision:    "cluster-current-1",
+			},
+		},
+	}
+	var completedSubmitter = &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-jobmanager",
+			Namespace: cluster.Namespace,
+			Labels: map[string]string{
+				RevisionNameLabel: "cluster-current",
+			},
+		},
+		Status: batchv1.JobStatus{Succeeded: 1},
+	}
+	var desiredJob = &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      completedSubmitter.Name,
+			Namespace: completedSubmitter.Namespace,
+			Labels: map[string]string{
+				RevisionNameLabel: "cluster-current",
+			},
+		},
+		Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Args: []string{"run"}}}},
+		}},
+	}
+	var fakeClient = fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(cluster).
+		WithObjects(cluster, completedSubmitter).
+		Build()
+	var reconciler = &ClusterReconciler{
+		k8sClient: fakeClient,
+		observed: ObservedClusterState{
+			cluster: cluster,
+			flinkJobSubmitter: FlinkJobSubmitter{
+				job: completedSubmitter,
+			},
+		},
+		desired: model.DesiredClusterState{Job: desiredJob},
+	}
+
+	_, err := reconciler.reconcileJob(context.Background())
+	assert.NilError(t, err)
+
+	var submitter batchv1.Job
+	err = fakeClient.Get(
+		context.Background(),
+		types.NamespacedName{Name: completedSubmitter.Name, Namespace: completedSubmitter.Namespace},
+		&submitter,
+	)
+	assert.Assert(t, apierrors.IsNotFound(err))
+}
+
+func TestReconcileJobKeepsSubmitterAtNextRevision(t *testing.T) {
+	var scheme = runtime.NewScheme()
+	assert.NilError(t, v1beta1.AddToScheme(scheme))
+	assert.NilError(t, batchv1.AddToScheme(scheme))
+
+	var applicationMode = v1beta1.JobModeApplication
+	var cluster = &v1beta1.FlinkCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "default"},
+		Spec: v1beta1.FlinkClusterSpec{
+			Job: &v1beta1.JobSpec{Mode: &applicationMode},
+		},
+		Status: v1beta1.FlinkClusterStatus{
+			Components: v1beta1.FlinkClusterComponentsStatus{
+				Job: &v1beta1.JobStatus{State: v1beta1.JobStateUpdating},
+			},
+			Revision: v1beta1.RevisionStatus{
+				CurrentRevision: "cluster-current-1",
+				NextRevision:    "cluster-next-2",
+			},
+		},
+	}
+	var nextRevisionSubmitter = &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      "cluster-jobmanager",
+		Namespace: cluster.Namespace,
+		Labels: map[string]string{
+			RevisionNameLabel: "cluster-next",
+		},
+	}}
+	var desiredJob = &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nextRevisionSubmitter.Name,
+			Namespace: nextRevisionSubmitter.Namespace,
+			Labels: map[string]string{
+				RevisionNameLabel: "cluster-next",
+			},
+		},
+		Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Args: []string{"standalone-job"}}}},
+		}},
+	}
+	var fakeClient = fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(cluster).
+		WithObjects(cluster, nextRevisionSubmitter).
+		Build()
+	var reconciler = &ClusterReconciler{
+		k8sClient: fakeClient,
+		observed: ObservedClusterState{
+			cluster: cluster,
+			flinkJobSubmitter: FlinkJobSubmitter{
+				job: nextRevisionSubmitter,
+			},
+		},
+		desired: model.DesiredClusterState{Job: desiredJob},
+	}
+
+	_, err := reconciler.reconcileJob(context.Background())
+	assert.NilError(t, err)
+
+	var submitter batchv1.Job
+	assert.NilError(t, fakeClient.Get(
+		context.Background(),
+		types.NamespacedName{Name: nextRevisionSubmitter.Name, Namespace: nextRevisionSubmitter.Namespace},
+		&submitter,
+	))
+}

--- a/controllers/flinkcluster/flinkcluster_updater.go
+++ b/controllers/flinkcluster/flinkcluster_updater.go
@@ -222,6 +222,10 @@ func (updater *ClusterStatusUpdater) deriveClusterStatus(
 	var status = v1beta1.FlinkClusterStatus{}
 	var runningComponents = 0
 
+	// Derive the job first so aggregate cluster state reflects the current observation.
+	var jobStatus = updater.deriveJobStatus(ctx)
+	status.Components.Job = jobStatus
+
 	// ConfigMap.
 	var observedConfigMap = observed.configMap
 	cmStatus := &status.Components.ConfigMap
@@ -456,7 +460,6 @@ func (updater *ClusterStatusUpdater) deriveClusterStatus(
 	}
 
 	// Derive the new cluster state.
-	var jobStatus = recorded.Components.Job
 	switch recorded.State {
 	case "", v1beta1.ClusterStateCreating:
 		if runningComponents < totalComponents {
@@ -528,16 +531,18 @@ func (updater *ClusterStatusUpdater) deriveClusterStatus(
 	case v1beta1.ClusterStateStopped:
 		if recorded.Revision.IsUpdateTriggered() {
 			status.State = v1beta1.ClusterStateUpdating
+		} else if jobStatus.IsActive() {
+			if runningComponents < totalComponents {
+				status.State = v1beta1.ClusterStateReconciling
+			} else {
+				status.State = v1beta1.ClusterStateRunning
+			}
 		} else {
 			status.State = v1beta1.ClusterStateStopped
 		}
 	default:
 		panic(fmt.Sprintf("Unknown cluster state: %v", recorded.State))
 	}
-
-	// (Optional) Job.
-	// Update job status.
-	status.Components.Job = updater.deriveJobStatus(ctx)
 
 	// (Optional) Savepoint.
 	// Update savepoint status if it is in progress or requested.

--- a/controllers/flinkcluster/flinkcluster_updater_test.go
+++ b/controllers/flinkcluster/flinkcluster_updater_test.go
@@ -23,6 +23,7 @@ import (
 	v1beta1 "github.com/spotify/flink-on-k8s-operator/apis/flinkcluster/v1beta1"
 	"gotest.tools/v3/assert"
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -215,4 +216,62 @@ func TestClusterStatus(t *testing.T) {
 		assert.Equal(t, newStatus.State, v1beta1.ClusterStateRunning)
 	})
 
+}
+
+func TestStoppedApplicationClusterRecoversFromActiveJob(t *testing.T) {
+	var applicationMode = v1beta1.JobModeApplication
+	var replicas int32 = 1
+
+	for _, test := range []struct {
+		name                 string
+		readyReplicas        int32
+		expectedClusterState v1beta1.ClusterState
+	}{
+		{name: "ready components", readyReplicas: 1, expectedClusterState: v1beta1.ClusterStateRunning},
+		{name: "unready components", readyReplicas: 0, expectedClusterState: v1beta1.ClusterStateReconciling},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var cluster = &v1beta1.FlinkCluster{
+				Spec: v1beta1.FlinkClusterSpec{
+					TaskManager: &v1beta1.TaskManagerSpec{DeploymentType: v1beta1.DeploymentTypeDeployment},
+					Job:         &v1beta1.JobSpec{Mode: &applicationMode},
+				},
+				Status: v1beta1.FlinkClusterStatus{
+					State: v1beta1.ClusterStateStopped,
+					Components: v1beta1.FlinkClusterComponentsStatus{
+						Job: &v1beta1.JobStatus{State: v1beta1.JobStateSucceeded},
+					},
+					Revision: v1beta1.RevisionStatus{
+						CurrentRevision: "cluster-current-1",
+						NextRevision:    "cluster-current-1",
+					},
+				},
+			}
+			var observed = ObservedClusterState{
+				cluster: cluster,
+				flinkJobSubmitter: FlinkJobSubmitter{
+					job: &batchv1.Job{Status: batchv1.JobStatus{Active: 1}},
+					pod: &corev1.Pod{},
+				},
+				jmService: &corev1.Service{Spec: corev1.ServiceSpec{
+					Type:      corev1.ServiceTypeClusterIP,
+					ClusterIP: "127.0.0.1",
+				}},
+				tmDeployment: &appsv1.Deployment{
+					Spec:   appsv1.DeploymentSpec{Replicas: &replicas},
+					Status: appsv1.DeploymentStatus{ReadyReplicas: test.readyReplicas},
+				},
+				revision: Revision{
+					currentRevision: &appsv1.ControllerRevision{ObjectMeta: metav1.ObjectMeta{Name: "cluster-current"}, Revision: 1},
+					nextRevision:    &appsv1.ControllerRevision{ObjectMeta: metav1.ObjectMeta{Name: "cluster-current"}, Revision: 1},
+				},
+			}
+
+			var updater = &ClusterStatusUpdater{observed: observed}
+			var status = updater.deriveClusterStatus(context.Background(), cluster, &observed)
+
+			assert.Equal(t, status.Components.Job.State, v1beta1.JobStateDeploying)
+			assert.Equal(t, status.State, test.expectedClusterState)
+		})
+	}
 }

--- a/controllers/flinkcluster/flinkcluster_util.go
+++ b/controllers/flinkcluster/flinkcluster_util.go
@@ -425,7 +425,9 @@ func isClusterUpdateToDate(observed *ObservedClusterState) bool {
 		observed.jmService,
 	}
 
-	if !IsApplicationModeCluster(observed.cluster) {
+	if IsApplicationModeCluster(observed.cluster) && !isScaleUpdate(observed.revisions, observed.cluster) {
+		components = append(components, observed.flinkJobSubmitter.job)
+	} else if !IsApplicationModeCluster(observed.cluster) {
 		components = append(components, observed.jmStatefulSet)
 	}
 

--- a/controllers/flinkcluster/flinkcluster_util_test.go
+++ b/controllers/flinkcluster/flinkcluster_util_test.go
@@ -323,6 +323,81 @@ func TestGetUpdateState(t *testing.T) {
 	assert.Equal(t, state, UpdateStateFinished)
 }
 
+func TestGetUpdateStateApplicationModeRequiresNextRevisionJob(t *testing.T) {
+	var applicationMode = v1beta1.JobModeApplication
+	var currentRevision = "cluster-current-2"
+	var nextRevision = "cluster-next-3"
+	var nextRevisionLabel = "cluster-next"
+	var observed = ObservedClusterState{
+		cluster: &v1beta1.FlinkCluster{
+			Spec: v1beta1.FlinkClusterSpec{
+				TaskManager: &v1beta1.TaskManagerSpec{DeploymentType: v1beta1.DeploymentTypeDeployment},
+				Job:         &v1beta1.JobSpec{Mode: &applicationMode},
+			},
+			Status: v1beta1.FlinkClusterStatus{
+				Components: v1beta1.FlinkClusterComponentsStatus{
+					Job: &v1beta1.JobStatus{State: v1beta1.JobStateUpdating, FinalSavepoint: true},
+				},
+				Revision: v1beta1.RevisionStatus{
+					CurrentRevision: currentRevision,
+					NextRevision:    nextRevision,
+				},
+			},
+		},
+		flinkJobSubmitter: FlinkJobSubmitter{job: &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{RevisionNameLabel: "cluster-before-hpa-scale"},
+		}}},
+		configMap: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{RevisionNameLabel: nextRevisionLabel}}},
+		tmService: &corev1.Service{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{RevisionNameLabel: nextRevisionLabel}}},
+		jmService: &corev1.Service{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{RevisionNameLabel: nextRevisionLabel}}},
+		tmDeployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+			RevisionNameLabel: nextRevisionLabel,
+		}}},
+	}
+
+	assert.Equal(t, getUpdateState(&observed), UpdateStateInProgress)
+
+	observed.flinkJobSubmitter.job.Labels[RevisionNameLabel] = nextRevisionLabel
+	assert.Equal(t, getUpdateState(&observed), UpdateStateFinished)
+}
+
+func TestGetUpdateStateApplicationModeScaleDoesNotRequireNewJob(t *testing.T) {
+	var applicationMode = v1beta1.JobModeApplication
+	var nextRevisionLabel = "cluster-scale"
+	var observed = ObservedClusterState{
+		cluster: &v1beta1.FlinkCluster{
+			Spec: v1beta1.FlinkClusterSpec{
+				TaskManager: &v1beta1.TaskManagerSpec{DeploymentType: v1beta1.DeploymentTypeDeployment},
+				Job:         &v1beta1.JobSpec{Mode: &applicationMode},
+			},
+			Status: v1beta1.FlinkClusterStatus{
+				Components: v1beta1.FlinkClusterComponentsStatus{
+					Job: &v1beta1.JobStatus{State: v1beta1.JobStateRunning},
+				},
+				Revision: v1beta1.RevisionStatus{
+					CurrentRevision: "cluster-before-scale-1",
+					NextRevision:    "cluster-scale-2",
+				},
+			},
+		},
+		revisions: []*appsv1.ControllerRevision{
+			{Revision: 1, Data: runtime.RawExtension{Raw: []byte(`{"spec":{"taskManager":{"replicas":1}}}`)}},
+			{Revision: 2, Data: runtime.RawExtension{Raw: []byte(`{"spec":{"taskManager":{"replicas":4}}}`)}},
+		},
+		flinkJobSubmitter: FlinkJobSubmitter{job: &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{RevisionNameLabel: "cluster-before-scale"},
+		}}},
+		configMap: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{RevisionNameLabel: nextRevisionLabel}}},
+		tmService: &corev1.Service{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{RevisionNameLabel: nextRevisionLabel}}},
+		jmService: &corev1.Service{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{RevisionNameLabel: nextRevisionLabel}}},
+		tmDeployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+			RevisionNameLabel: nextRevisionLabel,
+		}}},
+	}
+
+	assert.Equal(t, getUpdateState(&observed), UpdateStateFinished)
+}
+
 func TestHasTimeElapsed(t *testing.T) {
 	var tc = &util.TimeConverter{}
 	var timeToCheckStr = "2020-01-01T00:00:00+00:00"


### PR DESCRIPTION
## Summary

- during an application update, delete a submitter whenever it is not on the requested next revision
- preserve detached/session restart cleanup when no revision update is pending
- require the replacement application Job before completing non-scale updates while preserving HPA-only scale behavior
- derive aggregate cluster state from the latest observed job and recover stale `Stopped` states
- retry deploy-status updates after Kubernetes resource-version conflicts

## Problem

An HPA-only scale advances `currentRevision` without replacing the application-mode `batch/v1 Job`. A later job-spec update previously compared that older Job label to `currentRevision`, waited instead of deleting it, and marked the old Job as deploying. Revision completion also ignored the application Job. When the old JobManager exited successfully after the update savepoint, the operator classified the application as `Succeeded` and the cleanup policy removed the workers and HPA.

## Fix

Use the requested next revision to distinguish the replacement Job from any older submitter during an update. For non-scale application updates, keep `UpdateStateInProgress` until that next-revision Job is observed. Scale-only updates continue to complete without replacing the application Job.

When no update is pending, retain the existing restart behavior by deleting a completed submitter labeled with `currentRevision`. A submitter already labeled with `nextRevision` during an update is retained and allowed to progress.

Aggregate state now uses the freshly derived job status and can recover from `Stopped` when an active job is observed. Deploy-status updates retry Kubernetes resource-version conflicts.

Related to ES-885 and ES-887. PR #990 addresses the adjacent reactive/adaptive scheduler cancellation deadlock and is not included here.

## Testing

- `make test`
- full `go test ./...` on the final review fix
- regression coverage for HPA-only revision completion with an older application Job
- regression coverage for deleting a submitter older than `currentRevision` during the next update
- regression coverage for retaining a submitter already at `nextRevision`
- regression coverage for detached job restart cleanup with no revision update pending
- regression coverage for replacement-Job revision gating, stopped-state recovery, and status conflict retries
- live `flink-dev-gew` validation of the HPA-scale-then-update sequence: replacement Job created and final state `Running` / `Running`
- live `flink-dev-gew` validation of the ES-887 reactive annotation-update sequence: 62 samples, zero `Stopped` or terminal job states
