### PR TITLE
Consolidate FlinkCluster log summary into v1beta1

### DIFF
--- a/apis/flinkcluster/v1beta1/flinkcluster_logging.go
+++ b/apis/flinkcluster/v1beta1/flinkcluster_logging.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 Spotify AB.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+const logNilValue = "nil"
+
+// FlinkClusterLogSummary returns a compact representation of a FlinkCluster for logging.
+func FlinkClusterLogSummary(cluster *FlinkCluster) any {
+	if cluster == nil {
+		return logNilValue
+	}
+
+	kind := cluster.GetObjectKind().GroupVersionKind().Kind
+	if kind == "" {
+		kind = "FlinkCluster"
+	}
+
+	summary := map[string]any{
+		"kind":            kind,
+		"namespace":       cluster.Namespace,
+		"name":            cluster.Name,
+		"generation":      cluster.Generation,
+		"resourceVersion": cluster.ResourceVersion,
+		"flinkVersion":    cluster.Spec.FlinkVersion,
+		"image":           cluster.Spec.Image.Name,
+		"state":           cluster.Status.State,
+		"revision":        RevisionStatusLogSummary(cluster.Status.Revision),
+	}
+	if cluster.Spec.Job != nil {
+		summary["jobClass"] = cluster.Spec.Job.ClassName
+	}
+	if cluster.Spec.TaskManager != nil && cluster.Spec.TaskManager.Replicas != nil {
+		summary["taskManagerReplicas"] = *cluster.Spec.TaskManager.Replicas
+	}
+	if cluster.Status.Components.Job != nil {
+		summary["job"] = JobStatusLogSummary(cluster.Status.Components.Job)
+	}
+	if cluster.Status.Savepoint != nil {
+		summary["savepoint"] = SavepointStatusLogSummary(cluster.Status.Savepoint)
+	}
+	if cluster.Status.Control != nil {
+		summary["control"] = ControlStatusLogSummary(cluster.Status.Control)
+	}
+	return summary
+}
+
+// JobStatusLogSummary returns a compact representation of a job status for logging.
+func JobStatusLogSummary(status *JobStatus) any {
+	if status == nil {
+		return logNilValue
+	}
+	return map[string]any{
+		"id":                   status.ID,
+		"name":                 status.Name,
+		"submitterName":        status.SubmitterName,
+		"submitterExitCode":    status.SubmitterExitCode,
+		"state":                status.State,
+		"savepointGeneration":  status.SavepointGeneration,
+		"finalSavepoint":       status.FinalSavepoint,
+		"restartCount":         status.RestartCount,
+		"failureReasonCount":   len(status.FailureReasons),
+		"hasSavepointLocation": status.SavepointLocation != "",
+		"hasFromSavepoint":     status.FromSavepoint != "",
+	}
+}
+
+// ControlStatusLogSummary returns a compact representation of a control status for logging.
+func ControlStatusLogSummary(status *FlinkClusterControlStatus) any {
+	if status == nil {
+		return logNilValue
+	}
+	return map[string]any{
+		"name":        status.Name,
+		"state":       status.State,
+		"detailCount": len(status.Details),
+		"hasMessage":  status.Message != "",
+		"updateTime":  status.UpdateTime,
+	}
+}
+
+// SavepointStatusLogSummary returns a compact representation of a savepoint status for logging.
+func SavepointStatusLogSummary(status *SavepointStatus) any {
+	if status == nil {
+		return logNilValue
+	}
+	return map[string]any{
+		"jobID":       status.JobID,
+		"triggerID":   status.TriggerID,
+		"reason":      status.TriggerReason,
+		"state":       status.State,
+		"hasMessage":  status.Message != "",
+		"triggerTime": status.TriggerTime,
+		"updateTime":  status.UpdateTime,
+	}
+}
+
+// RevisionStatusLogSummary returns a compact representation of a revision status for logging.
+func RevisionStatusLogSummary(status RevisionStatus) map[string]any {
+	return map[string]any{
+		"currentRevision": status.CurrentRevision,
+		"nextRevision":    status.NextRevision,
+	}
+}

--- a/apis/flinkcluster/v1beta1/flinkcluster_webhook.go
+++ b/apis/flinkcluster/v1beta1/flinkcluster_webhook.go
@@ -29,33 +29,6 @@ import (
 
 var log = logf.Log.WithName("webhook")
 
-func flinkClusterLogSummary(cluster *FlinkCluster) any {
-	if cluster == nil {
-		return "nil"
-	}
-
-	summary := map[string]any{
-		"namespace":       cluster.Namespace,
-		"name":            cluster.Name,
-		"generation":      cluster.Generation,
-		"resourceVersion": cluster.ResourceVersion,
-		"flinkVersion":    cluster.Spec.FlinkVersion,
-		"image":           cluster.Spec.Image.Name,
-		"state":           cluster.Status.State,
-	}
-	if cluster.Spec.Job != nil {
-		summary["jobClass"] = cluster.Spec.Job.ClassName
-	}
-	if cluster.Spec.TaskManager != nil && cluster.Spec.TaskManager.Replicas != nil {
-		summary["taskManagerReplicas"] = *cluster.Spec.TaskManager.Replicas
-	}
-	if cluster.Status.Components.Job != nil {
-		summary["jobState"] = cluster.Status.Components.Job.State
-		summary["jobID"] = cluster.Status.Components.Job.ID
-	}
-	return summary
-}
-
 // flinkClusterDefaulter implements admission.CustomDefaulter for FlinkCluster.
 type flinkClusterDefaulter struct{}
 
@@ -82,9 +55,9 @@ The meaning of each marker can be found [here](/reference/markers/webhook.md).
 
 // Default implements admission.Defaulter[*FlinkCluster].
 func (d *flinkClusterDefaulter) Default(ctx context.Context, cluster *FlinkCluster) error {
-	log.Info("default", "cluster", flinkClusterLogSummary(cluster), "phase", "original")
+	log.Info("default", "cluster", FlinkClusterLogSummary(cluster), "phase", "original")
 	_SetDefault(cluster)
-	log.Info("default", "cluster", flinkClusterLogSummary(cluster), "phase", "augmented")
+	log.Info("default", "cluster", FlinkClusterLogSummary(cluster), "phase", "augmented")
 	return nil
 }
 

--- a/apis/flinkcluster/v1beta1/flinkcluster_webhook_logging_test.go
+++ b/apis/flinkcluster/v1beta1/flinkcluster_webhook_logging_test.go
@@ -27,9 +27,54 @@ func TestFlinkClusterLogSummaryDoesNotIncludeFullObject(t *testing.T) {
 				"log4j-console.properties": bigValue,
 			},
 		},
+		Status: FlinkClusterStatus{
+			Components: FlinkClusterComponentsStatus{
+				Job: &JobStatus{
+					ID:             "job-id",
+					State:          JobStateRunning,
+					FailureReasons: []string{bigValue},
+				},
+			},
+			Control: &FlinkClusterControlStatus{
+				Name:    "control",
+				Message: bigValue,
+			},
+			Savepoint: &SavepointStatus{
+				JobID:   "job-id",
+				Message: bigValue,
+			},
+			Revision: RevisionStatus{
+				CurrentRevision: "revision-1",
+				NextRevision:    "revision-2",
+			},
+		},
 	}
 
-	payload, err := json.Marshal(flinkClusterLogSummary(cluster))
+	summary := mustLogSummaryMap(t, FlinkClusterLogSummary(cluster))
+	if summary["kind"] != "FlinkCluster" {
+		t.Fatalf("summary has unexpected kind: %#v", summary["kind"])
+	}
+	job := mustLogSummaryMap(t, summary["job"])
+	if job["id"] != "job-id" || job["state"] != JobStateRunning {
+		t.Fatalf("summary has unexpected nested job: %#v", job)
+	}
+	if mustLogSummaryMap(t, summary["revision"])["currentRevision"] != "revision-1" {
+		t.Fatalf("summary lost revision: %#v", summary["revision"])
+	}
+	if mustLogSummaryMap(t, summary["savepoint"])["jobID"] != "job-id" {
+		t.Fatalf("summary lost savepoint: %#v", summary["savepoint"])
+	}
+	if mustLogSummaryMap(t, summary["control"])["name"] != "control" {
+		t.Fatalf("summary lost control: %#v", summary["control"])
+	}
+	if _, found := summary["jobID"]; found {
+		t.Fatalf("summary retained deprecated flat jobID key: %#v", summary)
+	}
+	if _, found := summary["jobState"]; found {
+		t.Fatalf("summary retained deprecated flat jobState key: %#v", summary)
+	}
+
+	payload, err := json.Marshal(summary)
 	if err != nil {
 		t.Fatalf("failed to marshal summary: %v", err)
 	}
@@ -37,10 +82,25 @@ func TestFlinkClusterLogSummaryDoesNotIncludeFullObject(t *testing.T) {
 	if strings.Contains(payloadString, bigValue[:100]) {
 		t.Fatalf("summary leaked full object content")
 	}
-	if len(payload) > 1_000 {
+	if len(payload) > 2_000 {
 		t.Fatalf("summary is unexpectedly large: %d bytes", len(payload))
 	}
 	if !strings.Contains(payloadString, "test-cluster") {
 		t.Fatalf("summary lost object identity: %s", payloadString)
 	}
+}
+
+func TestFlinkClusterLogSummaryHandlesNilCluster(t *testing.T) {
+	if got := FlinkClusterLogSummary(nil); got != logNilValue {
+		t.Fatalf("got %#v, want %#v", got, logNilValue)
+	}
+}
+
+func mustLogSummaryMap(t *testing.T, value any) map[string]any {
+	t.Helper()
+	summary, ok := value.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T (%#v)", value, value)
+	}
+	return summary
 }

--- a/controllers/flinkcluster/flinkcluster_logging.go
+++ b/controllers/flinkcluster/flinkcluster_logging.go
@@ -38,47 +38,13 @@ func logObjectSummary(obj client.Object) any {
 	return summary
 }
 
-func logFlinkClusterSummary(cluster *v1beta1.FlinkCluster) any {
-	if cluster == nil {
-		return logNilValue
-	}
-
-	summary := map[string]any{
-		"kind":            logObjectKind(cluster),
-		"namespace":       cluster.Namespace,
-		"name":            cluster.Name,
-		"generation":      cluster.Generation,
-		"resourceVersion": cluster.ResourceVersion,
-		"flinkVersion":    cluster.Spec.FlinkVersion,
-		"image":           cluster.Spec.Image.Name,
-		"state":           cluster.Status.State,
-		"revision":        logRevisionStatusSummary(cluster.Status.Revision),
-	}
-	if cluster.Spec.Job != nil {
-		summary["jobClass"] = cluster.Spec.Job.ClassName
-	}
-	if cluster.Spec.TaskManager != nil && cluster.Spec.TaskManager.Replicas != nil {
-		summary["taskManagerReplicas"] = *cluster.Spec.TaskManager.Replicas
-	}
-	if cluster.Status.Components.Job != nil {
-		summary["job"] = logJobStatusSummary(cluster.Status.Components.Job)
-	}
-	if cluster.Status.Savepoint != nil {
-		summary["savepoint"] = logSavepointStatusSummary(cluster.Status.Savepoint)
-	}
-	if cluster.Status.Control != nil {
-		summary["control"] = logControlStatusSummary(cluster.Status.Control)
-	}
-	return summary
-}
-
 func logObservedClusterStateSummary(observed *ObservedClusterState) map[string]any {
 	if observed == nil {
 		return map[string]any{"cluster": logNilValue}
 	}
 
 	summary := map[string]any{
-		"cluster":                 logFlinkClusterSummary(observed.cluster),
+		"cluster":                 v1beta1.FlinkClusterLogSummary(observed.cluster),
 		"controllerRevisions":     logControllerRevisionsSummary(observed.revisions),
 		"configMap":               logObjectSummary(observed.configMap),
 		"podDisruptionBudget":     logObjectSummary(observed.podDisruptionBudget),
@@ -198,10 +164,10 @@ func logClusterStatusSummary(status *v1beta1.FlinkClusterStatus) any {
 		"jobManagerService": logJobManagerServiceStatusSummary(status.Components.JobManagerService),
 		"jobManagerIngress": logJobManagerIngressStatusSummary(status.Components.JobManagerIngress),
 		"taskManager":       logTaskManagerStatusSummary(status.Components.TaskManager),
-		"job":               logJobStatusSummary(status.Components.Job),
-		"control":           logControlStatusSummary(status.Control),
-		"savepoint":         logSavepointStatusSummary(status.Savepoint),
-		"revision":          logRevisionStatusSummary(status.Revision),
+		"job":               v1beta1.JobStatusLogSummary(status.Components.Job),
+		"control":           v1beta1.ControlStatusLogSummary(status.Control),
+		"savepoint":         v1beta1.SavepointStatusLogSummary(status.Savepoint),
+		"revision":          v1beta1.RevisionStatusLogSummary(status.Revision),
 	}
 }
 
@@ -256,60 +222,6 @@ func logTaskManagerStatusSummary(status *v1beta1.TaskManagerStatus) any {
 		"replicas":      status.Replicas,
 		"readyReplicas": status.ReadyReplicas,
 		"ready":         status.Ready,
-	}
-}
-
-func logJobStatusSummary(status *v1beta1.JobStatus) any {
-	if status == nil {
-		return logNilValue
-	}
-	return map[string]any{
-		"id":                   status.ID,
-		"name":                 status.Name,
-		"submitterName":        status.SubmitterName,
-		"submitterExitCode":    status.SubmitterExitCode,
-		"state":                status.State,
-		"savepointGeneration":  status.SavepointGeneration,
-		"finalSavepoint":       status.FinalSavepoint,
-		"restartCount":         status.RestartCount,
-		"failureReasonCount":   len(status.FailureReasons),
-		"hasSavepointLocation": status.SavepointLocation != "",
-		"hasFromSavepoint":     status.FromSavepoint != "",
-	}
-}
-
-func logControlStatusSummary(status *v1beta1.FlinkClusterControlStatus) any {
-	if status == nil {
-		return logNilValue
-	}
-	return map[string]any{
-		"name":        status.Name,
-		"state":       status.State,
-		"detailCount": len(status.Details),
-		"hasMessage":  status.Message != "",
-		"updateTime":  status.UpdateTime,
-	}
-}
-
-func logSavepointStatusSummary(status *v1beta1.SavepointStatus) any {
-	if status == nil {
-		return logNilValue
-	}
-	return map[string]any{
-		"jobID":       status.JobID,
-		"triggerID":   status.TriggerID,
-		"reason":      status.TriggerReason,
-		"state":       status.State,
-		"hasMessage":  status.Message != "",
-		"triggerTime": status.TriggerTime,
-		"updateTime":  status.UpdateTime,
-	}
-}
-
-func logRevisionStatusSummary(status v1beta1.RevisionStatus) map[string]any {
-	return map[string]any{
-		"currentRevision": status.CurrentRevision,
-		"nextRevision":    status.NextRevision,
 	}
 }
 

--- a/controllers/flinkcluster/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler.go
@@ -882,7 +882,7 @@ func (reconciler *ClusterReconciler) updateStatus(
 		util.SetTimestamp(&newStatus.LastUpdateTime)
 		log.Info(
 			"Updating cluster status",
-			"cluster", logFlinkClusterSummary(clusterClone),
+			"cluster", v1beta1.FlinkClusterLogSummary(clusterClone),
 			"newStatus", logClusterStatusSummary(newStatus))
 		statusUpdateErr = reconciler.k8sClient.Status().Update(ctx, clusterClone)
 		if statusUpdateErr == nil {


### PR DESCRIPTION
# Consolidate FlinkCluster log summary into v1beta1

Follow-up to #1013 ("Compact operator state logs") based on post-merge review findings.

## Summary

- Move the canonical compact `FlinkCluster` log summary into `apis/flinkcluster/v1beta1`.
- Use that single implementation from both the admission webhook and controller logging paths.
- Move the job, control, savepoint, and revision status summary helpers alongside it so the cluster and status summaries cannot drift independently.
- Add focused coverage for the canonical rich shape and its nil-cluster branch.

## Operational log-shape change

**Dashboard and log-query owners:** webhook `default` logs now use the richer canonical controller shape. In particular, the flat `jobID` and `jobState` fields are replaced by the nested `job` summary, and `kind`, `revision`, `savepoint`, and `control` fields are emitted when applicable. This is an intentional follow-up to #1013 that removes two already-diverged implementations.

## Validation

- `CC=clang go build ./...`
- `CC=clang go vet ./apis/flinkcluster/v1beta1/ ./controllers/flinkcluster/`
- `CC=clang go test ./apis/flinkcluster/v1beta1/ -run 'LogSummary|FlinkClusterLogSummary' -count=1`
- `CC=clang go test ./controllers/flinkcluster/ -run TestLog -count=1`
