### PR TITLE
Make V(1) observed-state dump a complete superset

### DIFF
--- a/controllers/flinkcluster/flinkcluster_logging.go
+++ b/controllers/flinkcluster/flinkcluster_logging.go
@@ -81,6 +81,7 @@ func logObservedClusterStateSummary(observed *ObservedClusterState) map[string]a
 		"cluster":                 logFlinkClusterSummary(observed.cluster),
 		"controllerRevisions":     logControllerRevisionsSummary(observed.revisions),
 		"configMap":               logObjectSummary(observed.configMap),
+		"haConfigMap":             logObjectSummary(observed.haConfigMap),
 		"podDisruptionBudget":     logObjectSummary(observed.podDisruptionBudget),
 		"jobManagerStatefulSet":   logObjectSummary(observed.jmStatefulSet),
 		"jobManagerService":       logObjectSummary(observed.jmService),
@@ -134,6 +135,7 @@ func logObservedClusterStateFull(observed *ObservedClusterState) map[string]any 
 		"cluster":                 logFullObject(observed.cluster),
 		"controllerRevisions":     observed.revisions,
 		"configMap":               logFullObject(observed.configMap),
+		"haConfigMap":             logFullObject(observed.haConfigMap),
 		"podDisruptionBudget":     logFullObject(observed.podDisruptionBudget),
 		"jobManagerStatefulSet":   logFullObject(observed.jmStatefulSet),
 		"jobManagerService":       logFullObject(observed.jmService),
@@ -142,6 +144,13 @@ func logObservedClusterStateFull(observed *ObservedClusterState) map[string]any 
 		"taskManagerDeployment":   logFullObject(observed.tmDeployment),
 		"taskManagerService":      logFullObject(observed.tmService),
 		"horizontalPodAutoscaler": logFullObject(observed.horizontalPodAutoscaler),
+		"flinkJob":                logFullObject(observed.flinkJob.status),
+		"flinkJobList":            logFullObject(observed.flinkJob.list),
+		"flinkJobExceptions":      logFullObject(observed.flinkJob.exceptions),
+		"unexpectedFlinkJobs":     observed.flinkJob.unexpected,
+		"jobSubmitter":            logFullObject(observed.flinkJobSubmitter.job),
+		"jobSubmitterPod":         logFullObject(observed.flinkJobSubmitter.pod),
+		"jobSubmitterLog":         logSubmitterLogFull(observed.flinkJobSubmitter.log),
 		"savepoint":               logFullObject(observed.savepoint.status),
 	}
 	if observed.persistentVolumeClaims != nil {
@@ -365,6 +374,16 @@ func logSubmitterLogSummary(submitterLog *SubmitterLog) any {
 	}
 }
 
+func logSubmitterLogFull(submitterLog *SubmitterLog) any {
+	if submitterLog == nil {
+		return logNilValue
+	}
+	return map[string]any{
+		"jobID":   submitterLog.jobID,
+		"message": submitterLog.message,
+	}
+}
+
 func logFlinkSavepointSummary(status *flink.SavepointStatus, err error) any {
 	if status == nil && err == nil {
 		return logNilValue
@@ -404,12 +423,15 @@ func logObjectAPIVersion(obj client.Object) string {
 	return gvk.GroupVersion().String()
 }
 
-func isNilClientObject(obj client.Object) bool {
+func isNilClientObject(obj any) bool {
 	if obj == nil {
 		return true
 	}
 
-	value := reflect.ValueOf(obj)
+	return isNilReflectValue(reflect.ValueOf(obj))
+}
+
+func isNilReflectValue(value reflect.Value) bool {
 	switch value.Kind() {
 	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
 		return value.IsNil()

--- a/controllers/flinkcluster/flinkcluster_logging_test.go
+++ b/controllers/flinkcluster/flinkcluster_logging_test.go
@@ -2,15 +2,18 @@ package flinkcluster
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1 "github.com/spotify/flink-on-k8s-operator/apis/flinkcluster/v1beta1"
+	"github.com/spotify/flink-on-k8s-operator/internal/flink"
 	"github.com/spotify/flink-on-k8s-operator/internal/model"
 )
 
@@ -20,6 +23,51 @@ func TestLogObjectSummaryHandlesTypedNil(t *testing.T) {
 
 	if got := logObjectSummary(obj); got != logNilValue {
 		t.Fatalf("expected typed nil object to summarize as %q, got %#v", logNilValue, got)
+	}
+}
+
+func TestIsNilClientObjectHandlesNonPointerKinds(t *testing.T) {
+	var nilChan chan struct{}
+	var nilFunc func()
+	var nilMap map[string]string
+	var nilSlice []string
+
+	for name, value := range map[string]any{
+		"chan":  nilChan,
+		"func":  nilFunc,
+		"map":   nilMap,
+		"slice": nilSlice,
+	} {
+		t.Run(name+" nil", func(t *testing.T) {
+			if !isNilClientObject(value) {
+				t.Fatalf("expected nil %s to be detected", name)
+			}
+		})
+	}
+
+	for name, value := range map[string]any{
+		"chan":    make(chan struct{}),
+		"func":    func() {},
+		"map":     map[string]string{},
+		"slice":   []string{},
+		"default": 1,
+	} {
+		t.Run(name+" non-nil", func(t *testing.T) {
+			if isNilClientObject(value) {
+				t.Fatalf("expected non-nil %s not to be detected as nil", name)
+			}
+		})
+	}
+
+	// reflect.ValueOf unwraps an interface to its dynamic value, so exercise the
+	// interface branch with an addressable interface value directly.
+	var nilInterface any
+	if !isNilReflectValue(reflect.ValueOf(&nilInterface).Elem()) {
+		t.Fatal("expected nil interface to be detected")
+	}
+	nonNilInterface := any("value")
+	if isNilReflectValue(reflect.ValueOf(&nonNilInterface).Elem()) {
+		t.Fatal("expected non-nil interface not to be detected as nil")
 	}
 }
 
@@ -67,9 +115,19 @@ func TestLogObservedClusterStateSummaryDoesNotIncludeFullObjects(t *testing.T) {
 			"large": bigValue,
 		},
 	}
+	haConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ha-config",
+			Namespace: "test-namespace",
+		},
+		Data: map[string]string{
+			"large": bigValue,
+		},
+	}
 	observed := &ObservedClusterState{
-		cluster:   cluster,
-		configMap: configMap,
+		cluster:     cluster,
+		configMap:   configMap,
+		haConfigMap: haConfigMap,
 		revisions: []*appsv1.ControllerRevision{
 			{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster-abc-1"},
@@ -88,6 +146,10 @@ func TestLogObservedClusterStateSummaryDoesNotIncludeFullObjects(t *testing.T) {
 	}
 	if !strings.Contains(payloadString, "test-cluster") {
 		t.Fatalf("summary lost object identity: %s", payloadString)
+	}
+	haConfigMapSummary, ok := logObservedClusterStateSummary(observed)["haConfigMap"].(map[string]any)
+	if !ok || haConfigMapSummary["name"] != "test-ha-config" {
+		t.Fatalf("summary lost HA ConfigMap identity: %#v", haConfigMapSummary)
 	}
 }
 
@@ -116,15 +178,57 @@ func TestLogObservedClusterStateFullIncludesFullObjects(t *testing.T) {
 			"large": bigValue,
 		},
 	}
+	haConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ha-config"},
+		Data:       map[string]string{"ha-marker": bigValue},
+	}
 	observed := &ObservedClusterState{
-		cluster:   cluster,
-		configMap: configMap,
+		cluster:     cluster,
+		configMap:   configMap,
+		haConfigMap: haConfigMap,
+		flinkJob: FlinkJob{
+			status: &flink.Job{Id: "submitted-job-id", Name: "submitted-job-marker"},
+			list: &flink.JobsOverview{Jobs: []flink.Job{
+				{Id: "listed-job-id", Name: "listed-job-marker"},
+			}},
+			exceptions: &flink.JobExceptions{Exceptions: []flink.JobException{
+				{Exception: "exception-marker", Location: "exception-location"},
+			}},
+			unexpected: []string{"unexpected-job-marker"},
+		},
+		flinkJobSubmitter: FlinkJobSubmitter{
+			job: &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+				Name:        "submitter-job-marker",
+				Annotations: map[string]string{"large": bigValue},
+			}},
+			pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Name:        "submitter-pod-marker",
+				Annotations: map[string]string{"large": bigValue},
+			}},
+			log: &SubmitterLog{jobID: "submitter-log-job-id", message: "submitter-log-message-marker"},
+		},
 	}
 
-	payload := mustMarshalLogSummary(t, logObservedClusterStateFull(observed))
+	full := logObservedClusterStateFull(observed)
+	for _, key := range []string{
+		"haConfigMap", "flinkJob", "flinkJobList", "flinkJobExceptions",
+		"unexpectedFlinkJobs", "jobSubmitter", "jobSubmitterPod", "jobSubmitterLog",
+	} {
+		if _, ok := full[key]; !ok {
+			t.Errorf("full observed state log is missing %q", key)
+		}
+	}
+
+	payload := mustMarshalLogSummary(t, full)
 	payloadString := string(payload)
-	if !strings.Contains(payloadString, bigValue[:100]) {
-		t.Fatalf("full observed state log did not include full object content")
+	for _, marker := range []string{
+		bigValue[:100], "test-ha-config", "submitted-job-marker", "listed-job-marker",
+		"exception-marker", "unexpected-job-marker", "submitter-job-marker",
+		"submitter-pod-marker", "submitter-log-message-marker",
+	} {
+		if !strings.Contains(payloadString, marker) {
+			t.Errorf("full observed state log did not include marker %q", marker)
+		}
 	}
 	if len(payload) < 20_000 {
 		t.Fatalf("full observed state log is unexpectedly small: %d bytes", len(payload))


### PR DESCRIPTION
# Make the V(1) observed-state dump a complete superset

Follow-up to #1013 ("Compact operator state logs") based on post-merge review findings.

## Summary

- Add the full Flink job status, job list, job exceptions, and unexpected job IDs to the V(1)-gated observed-state dump.
- Add the full job submitter Job, Pod, and captured submitter log to that dump.
- Include the HA ConfigMap in both compact and full observed-state logging, closing a gap where it was previously absent from both.
- Preserve nil-safe logging for all newly included fields.

The full submitter log uses an explicit map because `SubmitterLog` has unexported fields and therefore cannot be serialized with `logFullObject` directly.

## Tests

- Expand the observed-state summary test to verify the HA ConfigMap is summarized without leaking its data.
- Expand the full-dump test with Flink job, exception, submitter, and HA ConfigMap fixtures and assert each full-content marker is retained.
- Cover nil and non-nil Chan, Func, Map, Slice, Interface, and non-nilable/default reflection branches used by typed-nil detection.

## Validation

- `CC=clang go build ./...`
- `CC=clang go vet ./controllers/flinkcluster/`
- `CC=clang go test ./controllers/flinkcluster/ -run 'TestLog|TestIsNil' -count=1`
