### PR TITLE
Propagate non-NotFound errors from deleteComponent

### DIFF
--- a/controllers/flinkcluster/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler.go
@@ -281,9 +281,9 @@ func (reconciler *ClusterReconciler) deleteComponent(
 	log := logr.FromContextOrDiscard(ctx).WithValues("component", component)
 	var k8sClient = reconciler.k8sClient
 
-	var err = k8sClient.Delete(ctx, obj)
-	if client.IgnoreNotFound(err) != nil {
+	if err := client.IgnoreNotFound(k8sClient.Delete(ctx, obj)); err != nil {
 		log.Error(err, "Failed to delete", "object", logObjectSummary(obj))
+		return err
 	}
 
 	log.Info("Deleted", "object", logObjectSummary(obj))

--- a/controllers/flinkcluster/flinkcluster_reconciler_delete_test.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler_delete_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2026 Spotify AB.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flinkcluster
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func TestDeleteComponent(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core types to scheme: %v", err)
+	}
+
+	t.Run("successful delete returns nil", func(t *testing.T) {
+		configMap := testDeleteConfigMap()
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(configMap).
+			Build()
+		reconciler := ClusterReconciler{k8sClient: fakeClient}
+
+		if err := reconciler.deleteComponent(ctx, configMap, "ConfigMap"); err != nil {
+			t.Fatalf("deleteComponent returned error: %v", err)
+		}
+	})
+
+	t.Run("not found returns nil", func(t *testing.T) {
+		configMap := testDeleteConfigMap()
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		reconciler := ClusterReconciler{k8sClient: fakeClient}
+
+		if err := reconciler.deleteComponent(ctx, configMap, "ConfigMap"); err != nil {
+			t.Fatalf("deleteComponent returned error for an absent object: %v", err)
+		}
+	})
+
+	t.Run("non-NotFound error is returned", func(t *testing.T) {
+		deleteErr := errors.New("delete failed")
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Delete: func(context.Context, client.WithWatch, client.Object, ...client.DeleteOption) error {
+					return deleteErr
+				},
+			}).
+			Build()
+		reconciler := ClusterReconciler{k8sClient: fakeClient}
+
+		err := reconciler.deleteComponent(ctx, testDeleteConfigMap(), "ConfigMap")
+		if !errors.Is(err, deleteErr) {
+			t.Fatalf("deleteComponent returned %v, want %v", err, deleteErr)
+		}
+	})
+}
+
+func testDeleteConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-config-map",
+			Namespace: "default",
+		},
+	}
+}


### PR DESCRIPTION
# Propagate non-NotFound errors from deleteComponent

Follow-up to #1013 ("Compact operator state logs") based on post-merge review findings.

## Summary

- Return non-NotFound Kubernetes delete errors from `deleteComponent` instead of silently treating them as success.
- Continue treating NotFound as an idempotent successful delete.
- Only emit the `Deleted` INFO log when the delete succeeds or the object was already absent; failures emit the existing Error log and return immediately.

## Behavior change

**Delete failures now propagate through the existing fail-fast reconcile call chain.** Controller-runtime will requeue the reconciliation with backoff. Previously, `deleteComponent` returned `nil` for every error, so the reconciler proceeded as if deletion had succeeded. On recreate paths this could leave the old object in place and surface a confusing `AlreadyExists` error on a later create instead of retrying the original delete failure.

No caller changes are required: `reconcileComponent` and the top-level reconcile flow already return non-nil errors.

## Test coverage

A focused fake-client unit test covers:

- successful deletion returns nil
- an absent object (NotFound) returns nil
- an intercepted non-NotFound delete error is returned to the caller

The test uses controller-runtime's fake client and does not require envtest.

## Validation

- `CC=clang go build ./...`
- `CC=clang go vet ./controllers/flinkcluster/`
- `CC=clang go test ./controllers/flinkcluster/ -run TestDeleteComponent -count=1`
- `CC=clang go test ./controllers/flinkcluster/ -run TestLog -count=1`
