### PR TITLE
docs: sync savepoint format artifacts

### DIFF
--- a/docs/crd.md
+++ b/docs/crd.md
@@ -367,6 +367,7 @@ _Appears in:_
 | `fromSavepoint` _string_ | _(Optional)_ FromSavepoint where to restore the job from Savepoint where to restore the job from (e.g., gs://my-savepoint/1234). If flink job must be restored from the latest available savepoint when Flink job updating, this field must be unspecified. |
 | `allowNonRestoredState` _boolean_ | Allow non-restored state, default: `false`. |
 | `savepointsDir` _string_ | _(Optional)_ Savepoints dir where to store savepoints of the job. |
+| `savepointFormatType` _SavepointFormatType_ | _(Optional)_ Savepoint format type, "CANONICAL" or "NATIVE", default: "CANONICAL". Requires Flink 1.15 or later. |
 | `takeSavepointOnUpdate` _boolean_ | _(Optional)_ Should take savepoint before updating job, default: `true`. If this is set as false, maxStateAgeToRestoreSeconds must be provided to limit the savepoint age to restore. |
 | `maxStateAgeToRestoreSeconds` _integer_ | _(Optional)_ Maximum age of the savepoint that allowed to restore state. This is applied to auto restart on failure, update from stopped state and update without taking savepoint. If nil, job can be restarted only when the latest savepoint is the final job state (created by "stop with savepoint") - that is, only when job can be resumed from the suspended state. |
 | `autoSavepointSeconds` _integer_ | _(Optional)_ Automatically take a savepoint to the `savepointsDir` every n seconds. |
@@ -468,6 +469,7 @@ _Appears in:_
 | `triggerReason` _SavepointReason_ | Savepoint triggered reason. |
 | `requestTime` _string_ | Savepoint status update time. |
 | `state` _string_ | Savepoint state. |
+| `formatType` _SavepointFormatType_ | Savepoint format type. |
 | `message` _string_ | Savepoint message. |
 
 

--- a/helm-chart/flink-operator/templates/flink-cluster-crd.yaml
+++ b/helm-chart/flink-operator/templates/flink-cluster-crd.yaml
@@ -1332,6 +1332,12 @@ spec:
                         - Never
                         - FromSavepointOnFailure
                       type: string
+                    savepointFormatType:
+                      default: CANONICAL
+                      enum:
+                        - CANONICAL
+                        - NATIVE
+                      type: string
                     savepointGeneration:
                       format: int32
                       type: integer
@@ -8498,6 +8504,8 @@ spec:
                   type: object
                 savepoint:
                   properties:
+                    formatType:
+                      type: string
                     jobID:
                       type: string
                     message:


### PR DESCRIPTION
## Summary

- document `savepointFormatType` and savepoint status `formatType` in the CRD API reference
- expose the same spec/status fields in the Helm-installed FlinkCluster CRD schema

Follow-up to #1002.

## Validation

- `git diff --check master...HEAD`
- `helm lint helm-chart/flink-operator`
- `helm template savepoint-format helm-chart/flink-operator`
- verified the rendered spec schema has `default: CANONICAL`, enum `CANONICAL`/`NATIVE`, and `type: string`
- verified the rendered status schema has `formatType: {type: string}`

## Scope

This intentionally keeps the artifact update narrow. The unpinned CRD-doc generator and a full Helm template refresh currently produce substantial unrelated churn, which is outside this follow-up.