### PR TITLE
fix: savepointFormatType defaults to nil

### DIFF
--- a/apis/flinkcluster/v1beta1/assets/test/flinkcluster_type_expected.yaml
+++ b/apis/flinkcluster/v1beta1/assets/test/flinkcluster_type_expected.yaml
@@ -40,7 +40,6 @@ spec:
   job:
     jarFile: ./examples/streaming/StateMachineExample.jar
     allowNonRestoredState: false
-    savepointFormatType: CANONICAL
     noLoggingToStdout: false
     restartPolicy: Never
     cleanupPolicy:

--- a/apis/flinkcluster/v1beta1/flinkcluster_types.go
+++ b/apis/flinkcluster/v1beta1/flinkcluster_types.go
@@ -576,9 +576,8 @@ type JobSpec struct {
 	// _(Optional)_ Savepoints dir where to store savepoints of the job.
 	SavepointsDir *string `json:"savepointsDir,omitempty"`
 
-	// _(Optional)_ Savepoint format type, "CANONICAL" or "NATIVE", default: "CANONICAL". Requires Flink 1.15 or later.
+	// _(Optional)_ Savepoint format type, "CANONICAL" or "NATIVE". Requires Flink 1.15 or later.
 	// +kubebuilder:validation:Enum=CANONICAL;NATIVE
-	// +kubebuilder:default:=CANONICAL
 	SavepointFormatType *SavepointFormatType `json:"savepointFormatType,omitempty"`
 
 	// _(Optional)_ Should take savepoint before updating job, default: `true`.

--- a/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
+++ b/config/crd/bases/flinkoperator.k8s.io_flinkclusters.yaml
@@ -1540,7 +1540,6 @@ spec:
                         - FromSavepointOnFailure
                       type: string
                     savepointFormatType:
-                      default: CANONICAL
                       enum:
                         - CANONICAL
                         - NATIVE

--- a/docs/crd.md
+++ b/docs/crd.md
@@ -513,7 +513,7 @@ _Appears in:_
 | `fromSavepoint` _string_ | _(Optional)_ FromSavepoint where to restore the job from<br />Savepoint where to restore the job from (e.g., gs://my-savepoint/1234).<br />If flink job must be restored from the latest available savepoint when Flink job updating, this field must be unspecified. |  |  |
 | `allowNonRestoredState` _boolean_ | Allow non-restored state, default: `false`. | false |  |
 | `savepointsDir` _string_ | _(Optional)_ Savepoints dir where to store savepoints of the job. |  |  |
-| `savepointFormatType` _[SavepointFormatType](#savepointformattype)_ | _(Optional)_ Savepoint format type, "CANONICAL" or "NATIVE", default: "CANONICAL". Requires Flink 1.15 or later. | CANONICAL | Enum: [CANONICAL NATIVE] <br /> |
+| `savepointFormatType` _[SavepointFormatType](#savepointformattype)_ | _(Optional)_ Savepoint format type, "CANONICAL" or "NATIVE". Requires Flink 1.15 or later. |  | Enum: [CANONICAL NATIVE] <br /> |
 | `takeSavepointOnUpdate` _boolean_ | _(Optional)_ Should take savepoint before updating job, default: `true`.<br />If this is set as false, maxStateAgeToRestoreSeconds must be provided to limit the savepoint age to restore. |  |  |
 | `maxStateAgeToRestoreSeconds` _integer_ | _(Optional)_ Maximum age of the savepoint that allowed to restore state.<br />This is applied to auto restart on failure, update from stopped state and update without taking savepoint.<br />If nil, job can be restarted only when the latest savepoint is the final job state (created by "stop with savepoint")<br />- that is, only when job can be resumed from the suspended state. |  | Minimum: 0 <br /> |
 | `autoSavepointSeconds` _integer_ | _(Optional)_ Automatically take a savepoint to the `savepointsDir` every n seconds. |  |  |


### PR DESCRIPTION
# Summary

Removes the `+kubebuilder:default:=CANONICAL` marker from `SavepointFormatType` so the field is nil when not set.

CRD and docs regenerated with commands below:
```bash
make manifests                                                                                                                                                                                    
make generate-crd-docs
```