### PR TITLE
Rotate job ID on restore from savepoint in Application mode

### DIFF
--- a/controllers/flinkcluster/flinkcluster_converter.go
+++ b/controllers/flinkcluster/flinkcluster_converter.go
@@ -138,7 +138,7 @@ func getDesiredClusterState(observed *ObservedClusterState) *model.DesiredCluste
 	return state
 }
 
-func newJobManagerContainer(flinkCluster *v1beta1.FlinkCluster) *corev1.Container {
+func newJobManagerContainer(flinkCluster *v1beta1.FlinkCluster, jobId string) *corev1.Container {
 	var clusterSpec = flinkCluster.Spec
 	var imageSpec = clusterSpec.Image
 	var jobManagerSpec = clusterSpec.JobManager
@@ -189,7 +189,6 @@ func newJobManagerContainer(flinkCluster *v1beta1.FlinkCluster) *corev1.Containe
 			args = append(args, "--allowNonRestoredState")
 		}
 
-		jobId, _ := GenJobId(flinkCluster)
 		args = append(args,
 			"--job-id", jobId,
 			"--job-classname", *jobSpec.ClassName,
@@ -237,7 +236,7 @@ func newJobManagerStatefulSet(flinkCluster *v1beta1.FlinkCluster) *appsv1.Statef
 	podLabels = mergeLabels(podLabels, jobManagerSpec.PodLabels)
 	var statefulSetLabels = mergeLabels(podLabels, getRevisionHashLabels(&flinkCluster.Status.Revision))
 
-	mainContainer := newJobManagerContainer(flinkCluster)
+	mainContainer := newJobManagerContainer(flinkCluster, "")
 	podSpec := newJobManagerPodSpec(mainContainer, flinkCluster)
 
 	var pvcs []corev1.PersistentVolumeClaim
@@ -900,7 +899,7 @@ func newJob(flinkCluster *v1beta1.FlinkCluster) *batchv1.Job {
 		labels = mergeLabels(labels, map[string]string{JobIdLabel: jobId})
 		jobName = getJobManagerJobName(flinkCluster.Name)
 		annotations = jobManagerSpec.PodAnnotations
-		mainContainer := newJobManagerContainer(flinkCluster)
+		mainContainer := newJobManagerContainer(flinkCluster, jobId)
 		podSpec = newJobManagerPodSpec(mainContainer, flinkCluster)
 	} else {
 		jobName = getSubmitterJobName(flinkCluster.Name)

--- a/controllers/flinkcluster/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler.go
@@ -1133,8 +1133,8 @@ func rotateJobIdIfNecessary(log logr.Logger, job *v1beta1.JobStatus, cluster *v1
 	if newJobId == "" || job.ID == newJobId {
 		return ""
 	}
-	job.ID = newJobId
 	log.Info("Job ID rotated for restore from savepoint", "oldJobId", job.ID, "newJobId", newJobId)
+	job.ID = newJobId
 	return newJobId
 }
 

--- a/controllers/flinkcluster/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler.go
@@ -595,7 +595,7 @@ func (reconciler *ClusterReconciler) reconcileJob(ctx context.Context) (ctrl.Res
 				return requeueResult, nil
 			}
 		} else {
-			if newJobId != "" && IsApplicationModeCluster(observed.cluster) {
+			if IsApplicationModeCluster(observed.cluster) && newJobId != "" {
 				patchJobId(desiredJob, newJobId)
 			}
 			err = reconciler.createJob(ctx, desiredJob)
@@ -1088,7 +1088,11 @@ func (reconciler *ClusterReconciler) updateJobDeployStatus(ctx context.Context) 
 		newJob = cluster.Status.Components.Job
 
 		// Reset running job information.
-		newJobId = rotateJobIdIfNecessary(log, newJob, &cluster)
+		newJobId = getNewJobIdIfNecessary(newJob, &cluster)
+		if newJobId != "" {
+			log.Info("Job ID rotated for deployment", "oldJobId", newJob.ID, "newJobId", newJobId)
+			newJob.ID = newJobId
+		}
 		newJob.StartTime = ""
 		newJob.CompletionTime = nil
 
@@ -1114,31 +1118,35 @@ func (reconciler *ClusterReconciler) updateJobDeployStatus(ctx context.Context) 
 	return newJobId, err
 }
 
-// rotateJobIdIfNecessary generates a fresh job ID for Application-mode clusters when restoring
-// from a savepoint to avoid archive path conflicts. When no restore location is resolved and
-// no final savepoint was taken, the existing ID is preserved so Flink's HA recovery can find its
-// checkpoints.
+// getNewJobIdIfNecessary returns a fresh job ID for Application-mode clusters when one is needed
+// to avoid archive path conflicts. HA clusters preserve the existing ID when no restore location
+// is resolved and no final savepoint was taken so Flink's HA recovery can find its checkpoints.
 // Detached-mode clusters are skipped because Flink assigns its own job ID.
-func rotateJobIdIfNecessary(log logr.Logger, job *v1beta1.JobStatus, cluster *v1beta1.FlinkCluster) string {
+func getNewJobIdIfNecessary(job *v1beta1.JobStatus, cluster *v1beta1.FlinkCluster) string {
 	if !IsApplicationModeCluster(cluster) {
 		return ""
 	}
 
 	restoreLocation := convertFromSavepoint(cluster.Spec.Job, job, &cluster.Status.Revision)
 
-	if !job.FinalSavepoint && restoreLocation == nil {
+	if cluster.IsHighAvailabilityEnabled() && !job.FinalSavepoint && restoreLocation == nil {
 		return ""
 	}
 	newJobId, _ := computeJobId(cluster)
 	if newJobId == "" || job.ID == newJobId {
 		return ""
 	}
-	log.Info("Job ID rotated for restore from savepoint", "oldJobId", job.ID, "newJobId", newJobId)
-	job.ID = newJobId
 	return newJobId
 }
 
 func patchJobId(job *batchv1.Job, newId string) {
+	if job.Labels == nil {
+		job.Labels = make(map[string]string)
+	}
+	if job.Spec.Template.Labels == nil {
+		job.Spec.Template.Labels = make(map[string]string)
+	}
+	job.Labels[JobIdLabel] = newId
 	job.Spec.Template.Labels[JobIdLabel] = newId
 	args := job.Spec.Template.Spec.Containers[0].Args
 	for i, arg := range args {

--- a/controllers/flinkcluster/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler.go
@@ -566,7 +566,7 @@ func (reconciler *ClusterReconciler) reconcileJob(ctx context.Context) (ctrl.Res
 		// Create Flink job submitter
 		log.Info("Updating job status to proceed creating new job submitter")
 		// Job status must be updated before creating a job submitter to ensure the observed job is the job submitted by the operator.
-		err = reconciler.updateJobDeployStatus(ctx)
+		newJobId, err := reconciler.updateJobDeployStatus(ctx)
 		if err != nil {
 			log.Info("Failed to update the job status for job submission")
 			return requeueResult, err
@@ -595,6 +595,9 @@ func (reconciler *ClusterReconciler) reconcileJob(ctx context.Context) (ctrl.Res
 				return requeueResult, nil
 			}
 		} else {
+			if newJobId != "" && IsApplicationModeCluster(observed.cluster) {
+				patchJobId(desiredJob, newJobId)
+			}
 			err = reconciler.createJob(ctx, desiredJob)
 		}
 
@@ -1068,11 +1071,12 @@ func (reconciler *ClusterReconciler) updateStatusWithJob(
 	}
 }
 
-func (reconciler *ClusterReconciler) updateJobDeployStatus(ctx context.Context) error {
+func (reconciler *ClusterReconciler) updateJobDeployStatus(ctx context.Context) (string, error) {
 	var log = logr.FromContextOrDiscard(ctx)
 	var observedCluster = reconciler.observed.cluster
 	var desiredJobSubmitter = reconciler.desired.Job
 	var newJob *v1beta1.JobStatus
+	var newJobId string
 	var key = types.NamespacedName{Namespace: observedCluster.Namespace, Name: observedCluster.Name}
 
 	var err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
@@ -1084,7 +1088,7 @@ func (reconciler *ClusterReconciler) updateJobDeployStatus(ctx context.Context) 
 		newJob = cluster.Status.Components.Job
 
 		// Reset running job information.
-		// newJob.ID = ""
+		newJobId = rotateJobIdIfNecessary(log, newJob, &cluster)
 		newJob.StartTime = ""
 		newJob.CompletionTime = nil
 
@@ -1107,7 +1111,42 @@ func (reconciler *ClusterReconciler) updateJobDeployStatus(ctx context.Context) 
 	} else {
 		log.Info("Succeeded to update job status for new job submitter.", "job status", newJob)
 	}
-	return err
+	return newJobId, err
+}
+
+// rotateJobIdIfNecessary generates a fresh job ID for Application-mode clusters when restoring
+// from a savepoint to avoid archive path conflicts. When no restore location is resolved and
+// no final savepoint was taken, the existing ID is preserved so Flink's HA recovery can find its
+// checkpoints.
+// Detached-mode clusters are skipped because Flink assigns its own job ID.
+func rotateJobIdIfNecessary(log logr.Logger, job *v1beta1.JobStatus, cluster *v1beta1.FlinkCluster) string {
+	if !IsApplicationModeCluster(cluster) {
+		return ""
+	}
+
+	restoreLocation := convertFromSavepoint(cluster.Spec.Job, job, &cluster.Status.Revision)
+
+	if !job.FinalSavepoint && restoreLocation == nil {
+		return ""
+	}
+	newJobId, _ := computeJobId(cluster)
+	if newJobId == "" || job.ID == newJobId {
+		return ""
+	}
+	job.ID = newJobId
+	log.Info("Job ID rotated for restore from savepoint", "oldJobId", job.ID, "newJobId", newJobId)
+	return newJobId
+}
+
+func patchJobId(job *batchv1.Job, newId string) {
+	job.Spec.Template.Labels[JobIdLabel] = newId
+	args := job.Spec.Template.Spec.Containers[0].Args
+	for i, arg := range args {
+		if arg == "--job-id" && i+1 < len(args) {
+			args[i+1] = newId
+			return
+		}
+	}
 }
 
 // getNewSavepointStatus returns newly triggered savepoint status.

--- a/controllers/flinkcluster/flinkcluster_reconciler_test.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler_test.go
@@ -83,7 +83,8 @@ func TestUpdateJobDeployStatusRetriesConflict(t *testing.T) {
 		desired:   model.DesiredClusterState{Job: desiredJob},
 	}
 
-	assert.NilError(t, reconciler.updateJobDeployStatus(context.Background()))
+	_, err := reconciler.updateJobDeployStatus(context.Background())
+	assert.NilError(t, err)
 	assert.Equal(t, updateCalls.Load(), int32(2))
 
 	var updated v1beta1.FlinkCluster
@@ -685,4 +686,233 @@ func assertNoSavepointStatus(t *testing.T, reconciler *ClusterReconciler, cluste
 	if updated.Status.Savepoint != nil {
 		t.Errorf("expected no savepoint status, got %+v", updated.Status.Savepoint)
 	}
+}
+
+func TestRotateJobIdOnExplicitFromSavepoint(t *testing.T) {
+	// given: an application-mode cluster restarting from an explicit savepoint,
+	// moving to a new revision, whose job status still has the old job ID
+	var scheme = runtime.NewScheme()
+	assert.NilError(t, v1beta1.AddToScheme(scheme))
+
+	fromSavepoint := "gs://bucket/explicit-savepoint"
+	var applicationMode = v1beta1.JobModeApplication
+	var cluster = &v1beta1.FlinkCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "default"},
+		Spec: v1beta1.FlinkClusterSpec{
+			Job: &v1beta1.JobSpec{
+				Mode:          &applicationMode,
+				FromSavepoint: &fromSavepoint,
+			},
+		},
+		Status: v1beta1.FlinkClusterStatus{
+			Components: v1beta1.FlinkClusterComponentsStatus{
+				Job: &v1beta1.JobStatus{
+					ID:             "old-job-id-that-should-be-rotated",
+					State:          v1beta1.JobStateUpdating,
+					FinalSavepoint: false,
+				},
+			},
+			Revision: v1beta1.RevisionStatus{
+				CurrentRevision: "cluster-abc123-1",
+				NextRevision:    "cluster-def456-2",
+			},
+		},
+	}
+	var fakeClient = fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(cluster).
+		WithObjects(cluster).
+		Build()
+
+	var desiredJob = &batchv1.Job{
+		Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{JobIdLabel: "old-job-id-that-should-be-rotated"},
+			},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{
+				Args: []string{
+					"standalone-job",
+					"--fromSavepoint", fromSavepoint,
+					"--job-id", "old-job-id-that-should-be-rotated",
+					"--job-classname", "com.example.Job",
+				},
+			}}},
+		}},
+	}
+	var reconciler = &ClusterReconciler{
+		k8sClient: fakeClient,
+		observed:  ObservedClusterState{cluster: cluster},
+		desired:   model.DesiredClusterState{Job: desiredJob},
+	}
+
+	// when: updateJobDeployStatus is called
+	newJobId, err := reconciler.updateJobDeployStatus(context.Background())
+
+	// then: a new, distinct job ID is generated
+	assert.NilError(t, err)
+	assert.Assert(t, newJobId != "")
+	assert.Assert(t, newJobId != "old-job-id-that-should-be-rotated")
+	assert.Equal(t, len(newJobId), 32)
+
+	// and: the cluster status is updated with the new job ID
+	var updated v1beta1.FlinkCluster
+	assert.NilError(t, fakeClient.Get(
+		context.Background(),
+		types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace},
+		&updated,
+	))
+	assert.Equal(t, updated.Status.Components.Job.ID, newJobId)
+
+	// when: the desired job is patched with the new job ID
+	patchJobId(desiredJob, newJobId)
+
+	// then: the pod template label and submitter args are updated to the new ID
+	assert.Equal(t, desiredJob.Spec.Template.Labels[JobIdLabel], newJobId)
+	assert.Equal(t, desiredJob.Spec.Template.Spec.Containers[0].Args[4], newJobId)
+}
+
+func TestRotateJobIdSkipsDetachedMode(t *testing.T) {
+	// given: a detached-mode job with an existing job ID and a final savepoint
+	log := logr.Discard()
+	var detachedMode = v1beta1.JobModeDetached
+	cluster := &v1beta1.FlinkCluster{
+		Spec: v1beta1.FlinkClusterSpec{
+			Job: &v1beta1.JobSpec{Mode: &detachedMode},
+		},
+		Status: v1beta1.FlinkClusterStatus{
+			Components: v1beta1.FlinkClusterComponentsStatus{
+				Job: &v1beta1.JobStatus{
+					ID:             "existing-id",
+					FinalSavepoint: true,
+				},
+			},
+			Revision: v1beta1.RevisionStatus{NextRevision: "cluster-abc-2"},
+		},
+	}
+
+	// when: rotateJobIdIfNecessary is called
+	result := rotateJobIdIfNecessary(log, cluster.Status.Components.Job, cluster)
+
+	// then: no rotation happens and the existing job ID is preserved
+	assert.Equal(t, result, "")
+	assert.Equal(t, cluster.Status.Components.Job.ID, "existing-id")
+}
+
+func TestRotateJobIdPreservesIdOnRecovery(t *testing.T) {
+	// given: an application-mode job recovering at the same revision (not restarting),
+	// with no final savepoint taken
+	log := logr.Discard()
+	var applicationMode = v1beta1.JobModeApplication
+	cluster := &v1beta1.FlinkCluster{
+		Spec: v1beta1.FlinkClusterSpec{
+			Job: &v1beta1.JobSpec{Mode: &applicationMode},
+		},
+		Status: v1beta1.FlinkClusterStatus{
+			Components: v1beta1.FlinkClusterComponentsStatus{
+				Job: &v1beta1.JobStatus{
+					ID:             "existing-id",
+					FinalSavepoint: false,
+				},
+			},
+			Revision: v1beta1.RevisionStatus{
+				CurrentRevision: "cluster-abc-2",
+				NextRevision:    "cluster-abc-2",
+			},
+		},
+	}
+
+	// when: rotateJobIdIfNecessary is called
+	result := rotateJobIdIfNecessary(log, cluster.Status.Components.Job, cluster)
+
+	// then: no rotation happens and the existing job ID is preserved
+	assert.Equal(t, result, "")
+	assert.Equal(t, cluster.Status.Components.Job.ID, "existing-id")
+}
+
+func TestGenJobIdIsDeterministic(t *testing.T) {
+	// given: a cluster with a fixed target revision and savepoint location
+	cluster := &v1beta1.FlinkCluster{
+		Spec: v1beta1.FlinkClusterSpec{
+			Job: &v1beta1.JobSpec{},
+		},
+		Status: v1beta1.FlinkClusterStatus{
+			Revision: v1beta1.RevisionStatus{NextRevision: "basic-example-85dc8f749-2"},
+			Components: v1beta1.FlinkClusterComponentsStatus{
+				Job: &v1beta1.JobStatus{SavepointLocation: "gs://bucket/sp-1"},
+			},
+		},
+	}
+
+	// when: GenJobId is called twice for the same inputs
+	id1, err1 := GenJobId(cluster)
+	id2, err2 := GenJobId(cluster)
+
+	// then: both calls return the same 32-character ID
+	assert.NilError(t, err1)
+	assert.NilError(t, err2)
+	assert.Equal(t, id1, id2)
+	assert.Equal(t, len(id1), 32)
+
+	// when: the savepoint location changes
+	cluster.Status.Components.Job.SavepointLocation = "gs://bucket/sp-2"
+	id3, err3 := GenJobId(cluster)
+
+	// then: a different ID is generated
+	assert.NilError(t, err3)
+	assert.Assert(t, id1 != id3)
+	assert.Equal(t, len(id3), 32)
+}
+
+func TestGenJobIdDiffersByClusterUID(t *testing.T) {
+	// given: two otherwise identical clusters differing only by UID
+	cluster1 := &v1beta1.FlinkCluster{
+		ObjectMeta: metav1.ObjectMeta{UID: "uid-1"},
+		Spec: v1beta1.FlinkClusterSpec{
+			Job: &v1beta1.JobSpec{},
+		},
+		Status: v1beta1.FlinkClusterStatus{
+			Revision: v1beta1.RevisionStatus{NextRevision: "basic-example-85dc8f749-2"},
+			Components: v1beta1.FlinkClusterComponentsStatus{
+				Job: &v1beta1.JobStatus{SavepointLocation: "gs://bucket/sp-1"},
+			},
+		},
+	}
+	cluster2 := cluster1.DeepCopy()
+	cluster2.UID = "uid-2"
+
+	// when: GenJobId is called for each cluster
+	id1, err1 := GenJobId(cluster1)
+	id2, err2 := GenJobId(cluster2)
+
+	// then: the generated IDs differ
+	assert.NilError(t, err1)
+	assert.NilError(t, err2)
+	assert.Assert(t, id1 != id2)
+}
+
+func TestPatchJobId(t *testing.T) {
+	// given: a job whose pod template label and submitter args reference an old job ID
+	job := &batchv1.Job{
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						JobIdLabel: "old-id",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Args: []string{"standalone-job", "--fromSavepoint", "gs://bucket/sp", "--job-id", "old-id", "--job-classname", "com.example.Job"},
+					}},
+				},
+			},
+		},
+	}
+
+	// when: patchJobId is called with a new job ID
+	patchJobId(job, "new-id-abc")
+
+	// then: the pod template label and submitter args are updated to the new ID
+	assert.Equal(t, job.Spec.Template.Labels[JobIdLabel], "new-id-abc")
+	assert.Equal(t, job.Spec.Template.Spec.Containers[0].Args[4], "new-id-abc")
 }

--- a/controllers/flinkcluster/flinkcluster_reconciler_test.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler_test.go
@@ -725,6 +725,9 @@ func TestRotateJobIdOnExplicitFromSavepoint(t *testing.T) {
 		Build()
 
 	var desiredJob = &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{JobIdLabel: "old-job-id-that-should-be-rotated"},
+		},
 		Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{JobIdLabel: "old-job-id-that-should-be-rotated"},
@@ -766,14 +769,14 @@ func TestRotateJobIdOnExplicitFromSavepoint(t *testing.T) {
 	// when: the desired job is patched with the new job ID
 	patchJobId(desiredJob, newJobId)
 
-	// then: the pod template label and submitter args are updated to the new ID
+	// then: the job label, pod template label, and submitter args are updated to the new ID
+	assert.Equal(t, desiredJob.Labels[JobIdLabel], newJobId)
 	assert.Equal(t, desiredJob.Spec.Template.Labels[JobIdLabel], newJobId)
 	assert.Equal(t, desiredJob.Spec.Template.Spec.Containers[0].Args[4], newJobId)
 }
 
-func TestRotateJobIdSkipsDetachedMode(t *testing.T) {
+func TestGetNewJobIdSkipsDetachedMode(t *testing.T) {
 	// given: a detached-mode job with an existing job ID and a final savepoint
-	log := logr.Discard()
 	var detachedMode = v1beta1.JobModeDetached
 	cluster := &v1beta1.FlinkCluster{
 		Spec: v1beta1.FlinkClusterSpec{
@@ -790,22 +793,86 @@ func TestRotateJobIdSkipsDetachedMode(t *testing.T) {
 		},
 	}
 
-	// when: rotateJobIdIfNecessary is called
-	result := rotateJobIdIfNecessary(log, cluster.Status.Components.Job, cluster)
+	// when: a new job ID is evaluated
+	result := getNewJobIdIfNecessary(cluster.Status.Components.Job, cluster)
 
 	// then: no rotation happens and the existing job ID is preserved
 	assert.Equal(t, result, "")
 	assert.Equal(t, cluster.Status.Components.Job.ID, "existing-id")
 }
 
-func TestRotateJobIdPreservesIdOnRecovery(t *testing.T) {
-	// given: an application-mode job recovering at the same revision (not restarting),
-	// with no final savepoint taken
-	log := logr.Discard()
+func TestGetNewJobIdForStatelessUpdateWithoutHA(t *testing.T) {
+	// given: a non-HA application-mode update with no savepoint to restore from
+	var applicationMode = v1beta1.JobModeApplication
+	cluster := &v1beta1.FlinkCluster{
+		ObjectMeta: metav1.ObjectMeta{UID: "cluster-uid"},
+		Spec: v1beta1.FlinkClusterSpec{
+			Job: &v1beta1.JobSpec{Mode: &applicationMode},
+		},
+		Status: v1beta1.FlinkClusterStatus{
+			Components: v1beta1.FlinkClusterComponentsStatus{
+				Job: &v1beta1.JobStatus{ID: "existing-id"},
+			},
+			Revision: v1beta1.RevisionStatus{
+				CurrentRevision: "cluster-abc-1",
+				NextRevision:    "cluster-def-2",
+			},
+		},
+	}
+	expectedJobId, err := computeJobId(cluster)
+	assert.NilError(t, err)
+
+	// when: a new job ID is evaluated
+	result := getNewJobIdIfNecessary(cluster.Status.Components.Job, cluster)
+
+	// then: a distinct ID is returned without mutating status
+	assert.Equal(t, result, expectedJobId)
+	assert.Equal(t, cluster.Status.Components.Job.ID, "existing-id")
+}
+
+func TestGetNewJobIdPreservesIdOnHAUpdateWithoutSavepoint(t *testing.T) {
+	// given: an HA application-mode update with no savepoint to restore from
 	var applicationMode = v1beta1.JobModeApplication
 	cluster := &v1beta1.FlinkCluster{
 		Spec: v1beta1.FlinkClusterSpec{
 			Job: &v1beta1.JobSpec{Mode: &applicationMode},
+			FlinkProperties: map[string]string{
+				"high-availability":            "kubernetes",
+				"kubernetes.cluster-id":        "cluster",
+				"high-availability.storageDir": "gs://bucket/ha",
+			},
+		},
+		Status: v1beta1.FlinkClusterStatus{
+			Components: v1beta1.FlinkClusterComponentsStatus{
+				Job: &v1beta1.JobStatus{ID: "existing-id"},
+			},
+			Revision: v1beta1.RevisionStatus{
+				CurrentRevision: "cluster-abc-1",
+				NextRevision:    "cluster-def-2",
+			},
+		},
+	}
+
+	// when: a new job ID is evaluated
+	result := getNewJobIdIfNecessary(cluster.Status.Components.Job, cluster)
+
+	// then: the existing ID is retained for HA checkpoint recovery
+	assert.Equal(t, result, "")
+	assert.Equal(t, cluster.Status.Components.Job.ID, "existing-id")
+}
+
+func TestGetNewJobIdPreservesIdOnHARecovery(t *testing.T) {
+	// given: an application-mode job recovering at the same revision (not restarting),
+	// with HA enabled and no final savepoint taken
+	var applicationMode = v1beta1.JobModeApplication
+	cluster := &v1beta1.FlinkCluster{
+		Spec: v1beta1.FlinkClusterSpec{
+			Job: &v1beta1.JobSpec{Mode: &applicationMode},
+			FlinkProperties: map[string]string{
+				"high-availability":            "kubernetes",
+				"kubernetes.cluster-id":        "cluster",
+				"high-availability.storageDir": "gs://bucket/ha",
+			},
 		},
 		Status: v1beta1.FlinkClusterStatus{
 			Components: v1beta1.FlinkClusterComponentsStatus{
@@ -821,8 +888,8 @@ func TestRotateJobIdPreservesIdOnRecovery(t *testing.T) {
 		},
 	}
 
-	// when: rotateJobIdIfNecessary is called
-	result := rotateJobIdIfNecessary(log, cluster.Status.Components.Job, cluster)
+	// when: a new job ID is evaluated
+	result := getNewJobIdIfNecessary(cluster.Status.Components.Job, cluster)
 
 	// then: no rotation happens and the existing job ID is preserved
 	assert.Equal(t, result, "")
@@ -890,9 +957,43 @@ func TestGenJobIdDiffersByClusterUID(t *testing.T) {
 	assert.Assert(t, id1 != id2)
 }
 
+func TestComputeJobIdDiffersByRestartCount(t *testing.T) {
+	// given: two attempts of the same revision restoring from the same savepoint
+	cluster := &v1beta1.FlinkCluster{
+		ObjectMeta: metav1.ObjectMeta{UID: "cluster-uid"},
+		Spec: v1beta1.FlinkClusterSpec{
+			Job: &v1beta1.JobSpec{},
+		},
+		Status: v1beta1.FlinkClusterStatus{
+			Revision: v1beta1.RevisionStatus{NextRevision: "cluster-revision-1"},
+			Components: v1beta1.FlinkClusterComponentsStatus{
+				Job: &v1beta1.JobStatus{
+					SavepointLocation: "gs://bucket/sp-1",
+					RestartCount:      1,
+				},
+			},
+		},
+	}
+	firstAttemptId, err := computeJobId(cluster)
+	assert.NilError(t, err)
+
+	// when: the trusted restart count advances
+	cluster.Status.Components.Job.RestartCount++
+	secondAttemptId, err := computeJobId(cluster)
+	assert.NilError(t, err)
+
+	// then: the logical deployment gets a distinct deterministic ID
+	assert.Assert(t, firstAttemptId != secondAttemptId)
+	assert.Equal(t, len(firstAttemptId), 32)
+	assert.Equal(t, len(secondAttemptId), 32)
+}
+
 func TestPatchJobId(t *testing.T) {
-	// given: a job whose pod template label and submitter args reference an old job ID
+	// given: a job whose labels and submitter args reference an old job ID
 	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{JobIdLabel: "old-id"},
+		},
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
@@ -912,7 +1013,8 @@ func TestPatchJobId(t *testing.T) {
 	// when: patchJobId is called with a new job ID
 	patchJobId(job, "new-id-abc")
 
-	// then: the pod template label and submitter args are updated to the new ID
+	// then: the job label, pod template label, and submitter args are updated to the new ID
+	assert.Equal(t, job.Labels[JobIdLabel], "new-id-abc")
 	assert.Equal(t, job.Spec.Template.Labels[JobIdLabel], "new-id-abc")
 	assert.Equal(t, job.Spec.Template.Spec.Containers[0].Args[4], "new-id-abc")
 }

--- a/controllers/flinkcluster/flinkcluster_util.go
+++ b/controllers/flinkcluster/flinkcluster_util.go
@@ -597,13 +597,17 @@ func computeJobId(cluster *v1beta1.FlinkCluster) (string, error) {
 	}
 
 	savepointLocation := ""
+	restartCount := int32(0)
 	if cluster.Spec.Job != nil {
 		restoreLocation := convertFromSavepoint(cluster.Spec.Job, cluster.Status.Components.Job, &cluster.Status.Revision)
 		if restoreLocation != nil {
 			savepointLocation = *restoreLocation
 		}
 	}
-	data := fmt.Sprintf("%s-%s-%s", cluster.UID, cluster.Status.Revision.NextRevision, savepointLocation)
+	if cluster.Status.Components.Job != nil {
+		restartCount = cluster.Status.Components.Job.RestartCount
+	}
+	data := fmt.Sprintf("%s-%s-%s-%d", cluster.UID, cluster.Status.Revision.NextRevision, savepointLocation, restartCount)
 	hash := md5.Sum([]byte(data))
 	return hex.EncodeToString(hash[:]), nil
 }

--- a/controllers/flinkcluster/flinkcluster_util.go
+++ b/controllers/flinkcluster/flinkcluster_util.go
@@ -588,11 +588,23 @@ func GenJobId(cluster *v1beta1.FlinkCluster) (string, error) {
 		return cluster.Status.Components.Job.ID, nil
 	}
 
+	return computeJobId(cluster)
+}
+
+func computeJobId(cluster *v1beta1.FlinkCluster) (string, error) {
 	if cluster == nil || len(cluster.Status.Revision.NextRevision) == 0 {
 		return "", fmt.Errorf("error generating job id: cluster or next revision is nil")
 	}
 
-	hash := md5.Sum([]byte(cluster.Status.Revision.NextRevision))
+	savepointLocation := ""
+	if cluster.Spec.Job != nil {
+		restoreLocation := convertFromSavepoint(cluster.Spec.Job, cluster.Status.Components.Job, &cluster.Status.Revision)
+		if restoreLocation != nil {
+			savepointLocation = *restoreLocation
+		}
+	}
+	data := fmt.Sprintf("%s-%s-%s", cluster.UID, cluster.Status.Revision.NextRevision, savepointLocation)
+	hash := md5.Sum([]byte(data))
 	return hex.EncodeToString(hash[:]), nil
 }
 


### PR DESCRIPTION
## Summary 

Assign a fresh deterministic JobID to Application-mode Flink jobs when redeploying from a savepoint. This prevents `FileAlreadyExistsException` failures caused by reusing JobID-scoped archive paths, while also separating checkpoint paths. The ID rotates after a graceful stop (`FinalSavepoint`), an explicit `spec.job.fromSavepoint` update or a redeployment triggered by `restartPolicy: FromSavepointOnFailure`, but remains unchanged after an ungraceful recovery such as a JobManager crash, so Flink HA can recover existing checkpoints. Deterministic generation makes subsequent reconciliations idempotent, and the behavior is limited to Application mode.

The JobID is deterministically calculated from the FlinkCluster UID, NextRevision, SavepointLocation, and RestartCount:
  - The FlinkCluster UID prevents different cluster instances with identical configurations from receiving the same JobID.
  - NextRevision generates a new JobID when the job configuration is updated.
  - The savepoint location distinguishes deployments restored from different savepoints.
  - RestartCount distinguishes repeated restoration attempts from the same savepoint and revision.

Together, these inputs keep the JobID stable across reconciliation retries for the same deployment while rotating it for updates, graceful restores, and repeated failure restarts.

This mirrors the lifecycle used by Apache Flink Kubernetes Operator’s [setJobIdIfNecessary](https://github.com/apache/flink-kubernetes-operator/blob/main/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java#L198-L224), which assigns a new persisted ID for a new logical deployment but preserves it for last-state recovery.

JobID of Session-mode Flink jobs is assigned by the Flink, not the operator.

This PR covers only the archiving structure that exists for Flink 2.2 and older. Since Flink 2.3 reorganizes the archiving structure [FLIP-549](https://cwiki.apache.org/confluence/spaces/FLINK/pages/386272238/FLIP-549+Support+Application+Management), Flink 2.3 will be covered in a separate PR.

## Known issues

`job.RestartCount` contributes to the JobID hash; however, `RestartCount` is currently never updated. As a result, when a job repeatedly reaches the "failed" state, only the first job is archived.

## Testing

Testing scenarios:

- [x] Flink 2.2.1. Streaming, Application deployment mode: fresh start -> update -> update -> update
- [x] Flink 2.2.1. Streaming, Application deployment mode: fresh start -> update -> job-cancel -> delete FlinkCluster -> create FlinkCluster with `fromSavepoint` -> update
- [x] Flink 2.2.1. Batch, Application deployment mode. The same FlinkCluster was run twice.
- [x] Flink 2.2.1. Streaming, Application deployment mode, with `restartPolicy: FromSavepointOnFailure`: fresh start -> failing job exceeds max-attempts -> job is restarted from the latest savepoint (bug, mentioned in known issues)
- [x] Flink 2.2.1 Streaming: -> operator upgrade (no mass restart)