### PR TITLE
Prevent duplicate stop-with-savepoint requests during job updates

### DIFF
--- a/controllers/flinkcluster/flinkcluster_controller.go
+++ b/controllers/flinkcluster/flinkcluster_controller.go
@@ -45,6 +45,7 @@ var controllerKind = v1beta1.GroupVersion.WithKind("FlinkCluster")
 // FlinkClusterReconciler reconciles a FlinkCluster object
 type FlinkClusterReconciler struct {
 	Client        client.Client
+	APIReader     client.Reader
 	Clientset     *kubernetes.Clientset
 	EventRecorder record.EventRecorder
 	Sharder       *Sharder
@@ -62,6 +63,7 @@ func NewReconciler(mgr manager.Manager) (*FlinkClusterReconciler, error) {
 
 	return &FlinkClusterReconciler{
 		Client:        mgr.GetClient(),
+		APIReader:     mgr.GetAPIReader(),
 		Clientset:     cs,
 		EventRecorder: mgr.GetEventRecorderFor("FlinkOperator"),
 		Sharder:       sh,
@@ -98,6 +100,7 @@ func (r *FlinkClusterReconciler) Reconcile(ctx context.Context,
 
 	var handler = FlinkClusterHandler{
 		k8sClient:     r.Client,
+		apiReader:     r.APIReader,
 		k8sClientset:  r.Clientset,
 		flinkClient:   flink.NewDefaultClient(log),
 		request:       request,
@@ -127,6 +130,7 @@ func (reconciler *FlinkClusterReconciler) SetupWithManager(
 // reconcile request.
 type FlinkClusterHandler struct {
 	k8sClient     client.Client
+	apiReader     client.Reader
 	k8sClientset  *kubernetes.Clientset
 	flinkClient   *flink.Client
 	request       ctrl.Request
@@ -204,6 +208,7 @@ func (handler *FlinkClusterHandler) reconcile(ctx context.Context,
 
 	var reconciler = ClusterReconciler{
 		k8sClient:   k8sClient,
+		apiReader:   handler.apiReader,
 		flinkClient: flinkClient,
 		observed:    handler.observed,
 		desired:     handler.desired,

--- a/controllers/flinkcluster/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler.go
@@ -55,6 +55,7 @@ const jobManagerShutdownFinalizer = "flinkoperator.k8s.io/jobmanager-shutdown"
 // desired state.
 type ClusterReconciler struct {
 	k8sClient   client.Client
+	apiReader   client.Reader
 	flinkClient *flink.Client
 	observed    ObservedClusterState
 	desired     model.DesiredClusterState
@@ -721,16 +722,23 @@ func (reconciler *ClusterReconciler) getFlinkJobID() string {
 
 func (reconciler *ClusterReconciler) trySuspendJob(ctx context.Context) (*v1beta1.SavepointStatus, error) {
 	log := logr.FromContextOrDiscard(ctx)
-	var recorded = reconciler.observed.cluster.Status
 
-	if !canTakeSavepoint(reconciler.observed.cluster) {
+	// Read directly from the API server because the informer cache may not yet contain
+	// the savepoint status written by the previous reconciliation. Using stale status
+	// here could trigger a duplicate, non-idempotent stop-with-savepoint request.
+	var liveCluster, err = reconciler.getLiveCluster(ctx)
+	if err != nil || liveCluster == nil {
+		return nil, err
+	}
+
+	if !canTakeSavepoint(liveCluster) {
 		return nil, nil
 	}
 
-	var jobID = reconciler.getFlinkJobID()
+	var jobID = liveCluster.Status.Components.Job.ID
 
 	log.Info("Checking the conditions for progressing")
-	var canSuspend = reconciler.canSuspendJob(ctx, jobID, recorded.Savepoint)
+	var canSuspend = reconciler.canSuspendJob(ctx, liveCluster)
 	if canSuspend {
 		log.Info("Stopping job with savepoint for update")
 		var newSavepointStatus, err = reconciler.triggerSavepoint(ctx, jobID, v1beta1.SavepointReasonUpdate, true)
@@ -743,6 +751,31 @@ func (reconciler *ClusterReconciler) trySuspendJob(ctx context.Context) (*v1beta
 	}
 
 	return nil, nil
+}
+
+func (reconciler *ClusterReconciler) getLiveCluster(ctx context.Context) (*v1beta1.FlinkCluster, error) {
+	log := logr.FromContextOrDiscard(ctx)
+	var observedCluster = reconciler.observed.cluster
+	var cluster v1beta1.FlinkCluster
+	var key = client.ObjectKeyFromObject(observedCluster)
+	if err := reconciler.apiReader.Get(ctx, key, &cluster); err != nil {
+		if errors.IsNotFound(err) {
+			log.Info("FlinkCluster no longer exists, skip stop with savepoint")
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read latest FlinkCluster before stopping job with savepoint: %w", err)
+	}
+
+	log.Info("Read latest FlinkCluster before stop with savepoint",
+		"cachedResourceVersion", observedCluster.ResourceVersion,
+		"liveResourceVersion", cluster.ResourceVersion)
+
+	var job = cluster.Status.Components.Job
+	if job == nil || job.ID == "" {
+		return nil, nil
+	}
+
+	return &cluster, nil
 }
 
 func (reconciler *ClusterReconciler) cancelJob(ctx context.Context) error {
@@ -877,8 +910,17 @@ func (reconciler *ClusterReconciler) waitForSavepointCompleted(ctx context.Conte
 }
 
 // canSuspendJob reports whether a new stop-with-savepoint request should be triggered.
-func (reconciler *ClusterReconciler) canSuspendJob(ctx context.Context, jobID string, s *v1beta1.SavepointStatus) bool {
+func (reconciler *ClusterReconciler) canSuspendJob(
+	ctx context.Context,
+	cluster *v1beta1.FlinkCluster,
+) bool {
 	log := logr.FromContextOrDiscard(ctx)
+	var job = cluster.Status.Components.Job
+	var jobID string
+	if job != nil {
+		jobID = job.ID
+	}
+	var s = cluster.Status.Savepoint
 	var firstTry = !finalSavepointRequested(jobID, s)
 	if firstTry {
 		return true
@@ -886,7 +928,6 @@ func (reconciler *ClusterReconciler) canSuspendJob(ctx context.Context, jobID st
 
 	switch s.State {
 	case v1beta1.SavepointStateSucceeded:
-		job := reconciler.observed.cluster.Status.Components.Job
 		if job != nil && !job.FinalSavepoint {
 			log.Info("Previous update savepoint does not belong to the current job execution")
 			return true
@@ -999,7 +1040,7 @@ func (reconciler *ClusterReconciler) triggerSavepoint(
 		triggerID = savepointTriggerID.RequestID
 		log.Info("Successfully savepoint triggered", "jobID", jobID, "triggerID", triggerID)
 	}
-	newSavepointStatus := reconciler.getNewSavepointStatus(triggerID, triggerReason, message, triggerSuccess, formatType)
+	newSavepointStatus := reconciler.getNewSavepointStatus(jobID, triggerID, triggerReason, message, triggerSuccess, formatType)
 
 	return newSavepointStatus, err
 }
@@ -1126,8 +1167,7 @@ func (reconciler *ClusterReconciler) updateJobDeployStatus(ctx context.Context) 
 }
 
 // getNewSavepointStatus returns newly triggered savepoint status.
-func (reconciler *ClusterReconciler) getNewSavepointStatus(triggerID string, triggerReason v1beta1.SavepointReason, message string, triggerSuccess bool, formatType v1beta1.SavepointFormatType) *v1beta1.SavepointStatus {
-	var jobID = reconciler.getFlinkJobID()
+func (reconciler *ClusterReconciler) getNewSavepointStatus(jobID string, triggerID string, triggerReason v1beta1.SavepointReason, message string, triggerSuccess bool, formatType v1beta1.SavepointFormatType) *v1beta1.SavepointStatus {
 	var savepointState string
 	var now string
 	util.SetTimestamp(&now)

--- a/controllers/flinkcluster/flinkcluster_reconciler_test.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler_test.go
@@ -466,6 +466,87 @@ func TestTrySuspendJobUsesStopWithSavepoint(t *testing.T) {
 	})
 }
 
+func TestTrySuspendJobDoesNotDuplicateStopWhenCachedSavepointIsStale(t *testing.T) {
+	// given: the first reconciliation observes the last scheduled savepoint
+	var stopCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		stopCalls.Add(1)
+		assert.Equal(t, r.Method, http.MethodPost)
+		assert.Equal(t, r.URL.Path, "/jobs/job-123/stop")
+		w.Header().Set("Content-Type", "application/json")
+		_, err := fmt.Fprint(w, `{"request-id": "trigger-update-a"}`)
+		assert.NilError(t, err)
+	}))
+	defer server.Close()
+
+	savepointsDir := "s3://bucket/savepoints"
+	staleCluster := newTestClusterWithJob(&savepointsDir, nil)
+	staleCluster.ResourceVersion = "1"
+	staleCluster.Status.Savepoint = &v1beta1.SavepointStatus{
+		JobID:         "job-123",
+		TriggerID:     "trigger-scheduled",
+		TriggerReason: v1beta1.SavepointReasonScheduled,
+		State:         v1beta1.SavepointStateSucceeded,
+	}
+	firstReconciler := newTestReconciler(staleCluster.DeepCopy(), newRedirectingHTTPClient(server.URL))
+
+	// and: the first reconciliation triggers update savepoint A
+	statusA, err := firstReconciler.trySuspendJob(context.Background())
+	assert.NilError(t, err)
+	assert.Assert(t, statusA != nil)
+	assert.Equal(t, stopCalls.Load(), int32(1))
+
+	// and: the next reconciliation still has the stale cached object, while the API server has A
+	liveCluster := staleCluster.DeepCopy()
+	liveCluster.ResourceVersion = "2"
+	liveCluster.Status.Savepoint = statusA
+	secondReconciler := newTestReconciler(staleCluster.DeepCopy(), newRedirectingHTTPClient(server.URL))
+	secondReconciler.apiReader = newTestAPIReader(t, liveCluster)
+
+	// when: the stale reconciliation tries to suspend the same job
+	statusB, err := secondReconciler.trySuspendJob(context.Background())
+
+	// then: the live read sees A in progress and no duplicate request B is sent
+	assert.NilError(t, err)
+	assert.Assert(t, statusB == nil)
+	assert.Equal(t, stopCalls.Load(), int32(1))
+}
+
+func TestTrySuspendJobHandlesLiveReadErrors(t *testing.T) {
+	savepointsDir := "s3://bucket/savepoints"
+	cluster := newTestClusterWithJob(&savepointsDir, nil)
+
+	t.Run("not found", func(t *testing.T) {
+		reconciler := newTestReconciler(cluster.DeepCopy(), http.DefaultClient)
+		reconciler.apiReader = newTestAPIReader(t)
+
+		status, err := reconciler.trySuspendJob(context.Background())
+
+		assert.NilError(t, err)
+		assert.Assert(t, status == nil)
+	})
+
+	t.Run("read failure", func(t *testing.T) {
+		reconciler := newTestReconciler(cluster.DeepCopy(), http.DefaultClient)
+		reconciler.apiReader = interceptor.NewClient(reconciler.k8sClient.(client.WithWatch), interceptor.Funcs{
+			Get: func(
+				context.Context,
+				client.WithWatch,
+				client.ObjectKey,
+				client.Object,
+				...client.GetOption,
+			) error {
+				return errors.New("API server unavailable")
+			},
+		})
+
+		status, err := reconciler.trySuspendJob(context.Background())
+
+		assert.Assert(t, status == nil)
+		requireError(t, err, "failed to read latest FlinkCluster", "API server unavailable")
+	})
+}
+
 func TestTrySuspendJobRecordsStopTriggerFailure(t *testing.T) {
 	// given: a Flink API that rejects the stop request
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -868,10 +949,27 @@ func newTestReconciler(cluster *v1beta1.FlinkCluster, httpClient *http.Client) *
 
 	return &ClusterReconciler{
 		k8sClient:   k8sClient,
+		apiReader:   k8sClient,
 		flinkClient: flink.NewClient(logr.Discard(), httpClient),
 		observed:    ObservedClusterState{cluster: cluster},
 		recorder:    record.NewFakeRecorder(16),
 	}
+}
+
+func newTestAPIReader(t *testing.T, clusters ...*v1beta1.FlinkCluster) client.Reader {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	assert.NilError(t, v1beta1.AddToScheme(scheme))
+
+	objects := make([]client.Object, len(clusters))
+	for i := range clusters {
+		objects[i] = clusters[i]
+	}
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&v1beta1.FlinkCluster{}).
+		WithObjects(objects...).
+		Build()
 }
 
 func newTestClusterWithJob(savepointsDir *string, flinkProperties map[string]string) *v1beta1.FlinkCluster {


### PR DESCRIPTION
## Summary

A reconciliation could read stale savepoint status from the informer cache immediately after a previous reconciliation triggered stop-with-savepoint. This could cause the operator to submit a second non-idempotent request for the same update. Read the latest FlinkCluster directly from the API server before stopping the job.

## Why

Example: we send one job update. The operator starts savepoint A, but the next reconciliation reads stale state and starts savepoint B. Savepoint A succeeds and stops the job; Savepoint B fails because the job is already stopped. The failure overwrites the successful status, so the operator retries and may stop the restored job again.

Here are the relevant logs, trimmed:

```
13:04:43.282 Successfully triggered stop with savepoint | triggerID=9abdc70cfe752dc9bee7bfda7543deb2
13:04:43.445 Next reconciliation observes the old scheduled savepoint | state=Succeeded reason=scheduled | triggerID=221f6fb5e693071ae96f376e8c7ddbc2
13:04:43.453 Successfully triggered stop with savepoint | triggerID=1464096ee4c4b3c021e9296d3bb7f582
13:04:43.544 Second trigger changes to Failed | "The Flink job is currently not executing"
13:04:53.753 Savepoint failed on previous request
```

Potential risks:
  - Misleading failure status. B commonly fails with “job is currently not executing,” and that failure can replace A’s valid status.
  - Loss of A’s trigger ID and result. The operator may no longer be able to poll A or obtain its savepoint location.

## How to reproduce?

Trigger two updates in quick succession, for example:

```bash
kubectl patch flinkcluster <flinkClusterName> -n <namespace> --type=merge -p '{"spec":{"flinkProperties":{"execution.checkpointing.timeout":"11 min"}}}' && \
kubectl patch flinkcluster <flinkClusterName> -n <namespace> --type=merge -p '{"spec":{"flinkProperties":{"execution.checkpointing.timeout":"12 min"}}}'
```
Job status:

```yaml
  savepoint:
    jobID: 89dd77e14559d1bce5d236a2d92e23f6
    message: "Failed to take savepoint for update. The update process is being postponed
      until a savepoint is available. Savepoint error: java.util.concurrent.CompletionException:
      org.apache.flink.runtime.checkpoint.CheckpointException: The Flink job is currently
      not executing. Failure reason: Trigger checkpoint failure.\n\tat java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:368)\n\tat
      java.base/java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:377)\n\tat
      java.base/java.util.concurrent.CompletableFuture$UniRelay.tryFire(CompletableFuture.java:1097)\n\tat
      java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)\n\tat
      java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2194)\n\tat
      org.apache.flink.runtime.rpc.pekko.PekkoInvocationHandler.lambda$invokeRpc$1(PekkoInvocationHandler.java:261)\n\tat
      java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863)\n\tat
      java.base/java."
    requestTime: "2026-08-27T06:19:23Z"
    state: Failed
    triggerID: ed992db80b35ab49750c9157521266e2
    triggerReason: update
    triggerTime: "2026-08-27T06:19:23Z"
```