### PR TITLE
Skip Flink job observation until the application JobManager is ready

### DIFF
--- a/controllers/flinkcluster/flinkcluster_observer.go
+++ b/controllers/flinkcluster/flinkcluster_observer.go
@@ -275,8 +275,8 @@ func (observer *ClusterStateObserver) observeJob(
 	}
 
 	// Get job submitter pod resource.
-	jobPod := new(corev1.Pod)
-	if err := observer.observeJobSubmitterPod(ctx, jobName, jobPod); err != nil {
+	var jobPod *corev1.Pod
+	if err := observer.observeJobSubmitterPod(ctx, jobName, &jobPod); err != nil {
 		if client.IgnoreNotFound(err) != nil {
 			log.Error(err, "job submitter corev1.Pod")
 		}
@@ -304,27 +304,26 @@ func (observer *ClusterStateObserver) observeJob(
 		log: submitterLog,
 	}
 
-	// Wait until the job manager is ready.
-	jmReady := applicationMode ||
-		(observed.jmStatefulSet != nil && getStatefulSetState(observed.jmStatefulSet) == v1beta1.ComponentStateReady)
-	if jmReady {
+	if isJmReady(applicationMode, observed, jobPod) {
+		var flinkJobID = getObservedFlinkJobID(jobPod, submitterLog, recordedJob)
 		// Observe the Flink job status.
-		var flinkJobID string
-		if jobID, ok := jobPod.Labels[JobIdLabel]; ok {
-			flinkJobID = jobID
-		} else
-		// Get the ID from the job submitter.
-		if submitterLog != nil && submitterLog.jobID != "" {
-			flinkJobID = submitterLog.jobID
-		} else
-		// Or get the job ID from the recorded job status which is written in previous iteration.
-		if recordedJob != nil {
-			flinkJobID = recordedJob.ID
-		}
 		observer.observeFlinkJobStatus(ctx, observed, flinkJobID, &observed.flinkJob)
 	}
 
 	return nil
+}
+
+func getObservedFlinkJobID(jobPod *corev1.Pod, submitterLog *SubmitterLog, recordedJob *v1beta1.JobStatus) string {
+	if jobPod != nil && jobPod.Labels[JobIdLabel] != "" {
+		return jobPod.Labels[JobIdLabel]
+	}
+	if submitterLog != nil && submitterLog.jobID != "" {
+		return submitterLog.jobID
+	}
+	if recordedJob != nil {
+		return recordedJob.ID
+	}
+	return ""
 }
 
 // Observes Flink job status through Flink API (instead of Kubernetes jobs through
@@ -409,6 +408,34 @@ func (observer *ClusterStateObserver) observeSavepoint(cluster *v1beta1.FlinkClu
 	savepoint.error = err
 
 	return err
+}
+
+func isJmReady(applicationMode bool, observed *ObservedClusterState, jobPod *corev1.Pod) bool {
+	if applicationMode {
+		return isJobManagerServiceAvailable(observed.jmService) &&
+			isApplicationJobManagerPodReady(jobPod)
+	}
+
+	return observed.jmStatefulSet != nil &&
+		getStatefulSetState(observed.jmStatefulSet) == v1beta1.ComponentStateReady
+}
+
+func isJobManagerServiceAvailable(service *corev1.Service) bool {
+	return service != nil && service.DeletionTimestamp == nil
+}
+
+func isApplicationJobManagerPodReady(pod *corev1.Pod) bool {
+	if pod == nil || pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning {
+		return false
+	}
+
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+
+	return false
 }
 
 func (observer *ClusterStateObserver) observeCluster(ctx context.Context, cluster *v1beta1.FlinkCluster) error {
@@ -596,7 +623,7 @@ func (observer *ClusterStateObserver) observeJobManagerIngress(
 func (observer *ClusterStateObserver) observeJobSubmitterPod(
 	ctx context.Context,
 	jobName string,
-	observedPod *corev1.Pod) error {
+	observedPod **corev1.Pod) error {
 	var clusterNamespace = observer.request.Namespace
 	var podSelector = labels.SelectorFromSet(map[string]string{"job-name": jobName})
 	var podList = new(corev1.PodList)
@@ -610,9 +637,9 @@ func (observer *ClusterStateObserver) observeJobSubmitterPod(
 		return err
 	}
 	if len(podList.Items) == 0 {
-		observedPod = nil
+		*observedPod = nil
 	} else {
-		podList.Items[0].DeepCopyInto(observedPod)
+		*observedPod = podList.Items[0].DeepCopy()
 	}
 
 	return nil

--- a/controllers/flinkcluster/flinkcluster_observer_test.go
+++ b/controllers/flinkcluster/flinkcluster_observer_test.go
@@ -9,9 +9,11 @@ import (
 	"github.com/spotify/flink-on-k8s-operator/internal/controllers/history"
 	"github.com/spotify/flink-on-k8s-operator/internal/util"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
 )
 
 // fakeHistory implements history.Interface for testing syncRevisionStatus.
@@ -332,4 +334,173 @@ func TestSyncRevisionStatus_RealCollisionIncrementsCount(t *testing.T) {
 		t.Log("Note: currentRevision == nextRevision (expected on first reconciliation with change)")
 	}
 	_ = fmt.Sprintf("collisionCount after real collision: %d", observed.revision.collisionCount)
+}
+
+func TestIsJmReady(t *testing.T) {
+	readyPod := &corev1.Pod{
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	}
+	terminatingPod := readyPod.DeepCopy()
+	deletionTime := metav1.Now()
+	terminatingPod.DeletionTimestamp = &deletionTime
+	pendingPod := readyPod.DeepCopy()
+	pendingPod.Status.Phase = corev1.PodPending
+	notReadyPod := readyPod.DeepCopy()
+	notReadyPod.Status.Conditions[0].Status = corev1.ConditionFalse
+	readyStatefulSet := &appsv1.StatefulSet{
+		Spec:   appsv1.StatefulSetSpec{Replicas: ptr.To(int32(1))},
+		Status: appsv1.StatefulSetStatus{ReadyReplicas: 1},
+	}
+	notReadyStatefulSet := readyStatefulSet.DeepCopy()
+	notReadyStatefulSet.Status.ReadyReplicas = 0
+	terminatingService := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		DeletionTimestamp: &deletionTime,
+	}}
+
+	tests := []struct {
+		name            string
+		applicationMode bool
+		service         *corev1.Service
+		jobPod          *corev1.Pod
+		statefulSet     *appsv1.StatefulSet
+		expected        bool
+	}{
+		{
+			name:            "application mode with absent service",
+			applicationMode: true,
+			jobPod:          readyPod,
+			expected:        false,
+		},
+		{
+			name:            "application mode with terminating service",
+			applicationMode: true,
+			service:         terminatingService,
+			jobPod:          readyPod,
+			expected:        false,
+		},
+		{
+			name:            "application mode with absent pod",
+			applicationMode: true,
+			service:         &corev1.Service{},
+			expected:        false,
+		},
+		{
+			name:            "application mode with terminating pod",
+			applicationMode: true,
+			service:         &corev1.Service{},
+			jobPod:          terminatingPod,
+			expected:        false,
+		},
+		{
+			name:            "application mode with non-running pod",
+			applicationMode: true,
+			service:         &corev1.Service{},
+			jobPod:          pendingPod,
+			expected:        false,
+		},
+		{
+			name:            "application mode with non-ready pod",
+			applicationMode: true,
+			service:         &corev1.Service{},
+			jobPod:          notReadyPod,
+			expected:        false,
+		},
+		{
+			name:            "application mode with ready service and pod",
+			applicationMode: true,
+			service:         &corev1.Service{},
+			jobPod:          readyPod,
+			expected:        true,
+		},
+		{
+			name:            "non-application mode with absent statefulset",
+			applicationMode: false,
+			expected:        false,
+		},
+		{
+			name:            "non-application mode with non-ready statefulset",
+			applicationMode: false,
+			statefulSet:     notReadyStatefulSet,
+			expected:        false,
+		},
+		{
+			name:            "non-application mode with ready statefulset",
+			applicationMode: false,
+			statefulSet:     readyStatefulSet,
+			expected:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// given: the specified deployment mode and JobManager resources
+			observed := &ObservedClusterState{
+				jmService:     tt.service,
+				jmStatefulSet: tt.statefulSet,
+			}
+
+			// when: JobManager readiness is evaluated
+			actual := isJmReady(tt.applicationMode, observed, tt.jobPod)
+
+			// then: the expected readiness is returned
+			if actual != tt.expected {
+				t.Fatalf("expected readiness %t, got %t", tt.expected, actual)
+			}
+		})
+	}
+}
+
+func TestGetObservedFlinkJobID(t *testing.T) {
+	tests := []struct {
+		name         string
+		jobPod       *corev1.Pod
+		submitterLog *SubmitterLog
+		recordedJob  *v1beta1.JobStatus
+		expected     string
+	}{
+		{
+			name:         "pod label is preferred",
+			jobPod:       &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{JobIdLabel: "pod-job-id"}}},
+			submitterLog: &SubmitterLog{jobID: "log-job-id"},
+			recordedJob:  &v1beta1.JobStatus{ID: "recorded-job-id"},
+			expected:     "pod-job-id",
+		},
+		{
+			name:         "submitter log is used without a pod",
+			submitterLog: &SubmitterLog{jobID: "log-job-id"},
+			recordedJob:  &v1beta1.JobStatus{ID: "recorded-job-id"},
+			expected:     "log-job-id",
+		},
+		{
+			name:        "recorded job is used without a pod or log",
+			recordedJob: &v1beta1.JobStatus{ID: "recorded-job-id"},
+			expected:    "recorded-job-id",
+		},
+		{
+			name: "job ID is absent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// given: the observed job ID sources
+			jobPod := tt.jobPod
+			submitterLog := tt.submitterLog
+			recordedJob := tt.recordedJob
+
+			// when: the Flink job ID is selected
+			actual := getObservedFlinkJobID(jobPod, submitterLog, recordedJob)
+
+			// then: the first available job ID is returned
+			if actual != tt.expected {
+				t.Fatalf("expected job ID %q, got %q", tt.expected, actual)
+			}
+		})
+	}
 }

--- a/controllers/flinkcluster/flinkcluster_updater.go
+++ b/controllers/flinkcluster/flinkcluster_updater.go
@@ -609,12 +609,14 @@ func (updater *ClusterStatusUpdater) getFlinkJobID() *string {
 	return nil
 }
 func (updater *ClusterStatusUpdater) deriveJobSubmitterExitCodeAndReason(pod *corev1.Pod, job *batchv1.Job) (int32, string) {
-	for _, containerStatus := range pod.Status.ContainerStatuses {
-		if containerStatus.Name == jobSubmitterPodMainContainerName && containerStatus.State.Terminated != nil {
-			exitCode := containerStatus.State.Terminated.ExitCode
-			reason := containerStatus.State.Terminated.Reason
-			message := containerStatus.State.Terminated.Message
-			return exitCode, fmt.Sprintf("[Exit code: %d] Reason: %s, Message: %s", exitCode, reason, message)
+	if pod != nil {
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+			if containerStatus.Name == jobSubmitterPodMainContainerName && containerStatus.State.Terminated != nil {
+				exitCode := containerStatus.State.Terminated.ExitCode
+				reason := containerStatus.State.Terminated.Reason
+				message := containerStatus.State.Terminated.Message
+				return exitCode, fmt.Sprintf("[Exit code: %d] Reason: %s, Message: %s", exitCode, reason, message)
+			}
 		}
 	}
 	// In some cases, the finished pod maybe collected by k8s garbage collector. In this case, we use job.Status to fill it

--- a/controllers/flinkcluster/flinkcluster_updater_test.go
+++ b/controllers/flinkcluster/flinkcluster_updater_test.go
@@ -239,6 +239,19 @@ func TestDeriveControlStatus_StopWithSavepointCancel(t *testing.T) {
 	})
 }
 
+func TestDeriveJobSubmitterExitCodeWithoutPod(t *testing.T) {
+	// given: a Job whose submitter pod has not been observed
+	updater := &ClusterStatusUpdater{}
+	job := &batchv1.Job{}
+
+	// when: the submitter exit code is derived
+	exitCode, reason := updater.deriveJobSubmitterExitCodeAndReason(nil, job)
+
+	// then: the Job is treated as still pending instead of dereferencing the missing pod
+	assert.Equal(t, exitCode, int32(-1))
+	assert.Equal(t, reason, "")
+}
+
 func TestStoppedApplicationClusterRecoversFromActiveJob(t *testing.T) {
 	var applicationMode = v1beta1.JobModeApplication
 	var replicas int32 = 1


### PR DESCRIPTION
## Summary

In `observeJob()` the operator assumes that JobManager in application-mode Flink cluster is unconditionally ready.

```go
jmReady := applicationMode ||
		(observed.jmStatefulSet != nil && getStatefulSetState(observed.jmStatefulSet) == v1beta1.ComponentStateReady)
```

In consequence, during an Application-mode update, the operator deletes the JobManager Service and submitter Job, then immediately attempt to query the old Flink REST endpoint, which fails eventually:

```json
{
  "ts": "2026-09-11T07:53:20Z",
  "msg": "---------- 1. Observe the current state ----------",
  "controller": "flinkcluster",
  "controllerGroup": "flinkoperator.k8s.io",
  "controllerKind": "FlinkCluster",
  "FlinkCluster": {"name": "event-counter", "namespace": "examples-streaming-java-production"},
  "namespace": "examples-streaming-java-production",
  "name": "event-counter",
  "reconcileID": "8b7319d4-c33b-44f9-ab3e-47bd5bd1e199"
}
{
  "ts": "2026-09-11T07:53:50Z",
  "msg": "Failed to get Flink job status list.",
  "controller": "flinkcluster",
  "controllerGroup": "flinkoperator.k8s.io",
  "controllerKind": "FlinkCluster",
  "FlinkCluster": {"name": "event-counter", "namespace": "examples-streaming-java-production"},
  "namespace": "examples-streaming-java-production",
  "name": "event-counter",
  "reconcileID": "8b7319d4-c33b-44f9-ab3e-47bd5bd1e199",
  "error": "Get \"http://event-counter-jobmanager.examples-streaming-java-production.svc.cluster.local:8081/jobs/overview\": dial tcp 10.160.149.208:8081: i/o timeout"
}
```

This request blocks reconciliation for 30s (`2026-09-11T07:53:20Z` - `2026-09-11T07:53:50Z`) until the network timeout expires, increasing restart time.

Require both the JobManager Service and submitter pod to be available before observing Flink job status in Application mode. The pod must be running, ready, and not terminating. Other deployment modes retain their existing StatefulSet readiness check.

## Additional fixes

`observeJobSubmitterPod()` now returns `nil` when the Kubernetes Job or its pod has not been observed. Previously, assigning nil to the local pointer did not update the caller, leaving it with an empty pod object. Status derivation now handles the absent pod safely.

Pod lookup now uses the current Kubernetes Job’s selector instead of the shared job-name label or the Flink job ID. During an update, a terminating pod from the previous Kubernetes Job can coexist with the replacement pod, while both share the same Job name and may share the same Flink job ID. The Kubernetes Job selector includes its unique controller UID, ensuring that only pods belonging to the current Job instance are considered.

```yaml
  labels:
    batch.kubernetes.io/controller-uid: 00856ef0-324e-4395-bf5b-5c0239ac6fac
    batch.kubernetes.io/job-name: event-counter-jobmanager
```