### PR TITLE
Make the Flink REST client timeout configurable

### DIFF
--- a/controllers/flinkcluster/flinkcluster_controller.go
+++ b/controllers/flinkcluster/flinkcluster_controller.go
@@ -44,13 +44,14 @@ var controllerKind = v1beta1.GroupVersion.WithKind("FlinkCluster")
 
 // FlinkClusterReconciler reconciles a FlinkCluster object
 type FlinkClusterReconciler struct {
-	Client        client.Client
-	Clientset     *kubernetes.Clientset
-	EventRecorder record.EventRecorder
-	Sharder       *Sharder
+	Client             client.Client
+	Clientset          *kubernetes.Clientset
+	EventRecorder      record.EventRecorder
+	Sharder            *Sharder
+	flinkClientTimeout time.Duration
 }
 
-func NewReconciler(mgr manager.Manager) (*FlinkClusterReconciler, error) {
+func NewReconciler(mgr manager.Manager, flinkClientTimeout time.Duration) (*FlinkClusterReconciler, error) {
 	cs, err := kubernetes.NewForConfig(mgr.GetConfig())
 	if err != nil {
 		return nil, err
@@ -61,10 +62,11 @@ func NewReconciler(mgr manager.Manager) (*FlinkClusterReconciler, error) {
 	}
 
 	return &FlinkClusterReconciler{
-		Client:        mgr.GetClient(),
-		Clientset:     cs,
-		EventRecorder: mgr.GetEventRecorderFor("FlinkOperator"),
-		Sharder:       sh,
+		Client:             mgr.GetClient(),
+		Clientset:          cs,
+		EventRecorder:      mgr.GetEventRecorderFor("FlinkOperator"),
+		Sharder:            sh,
+		flinkClientTimeout: flinkClientTimeout,
 	}, nil
 }
 
@@ -99,7 +101,7 @@ func (r *FlinkClusterReconciler) Reconcile(ctx context.Context,
 	var handler = FlinkClusterHandler{
 		k8sClient:     r.Client,
 		k8sClientset:  r.Clientset,
-		flinkClient:   flink.NewDefaultClient(log),
+		flinkClient:   flink.NewDefaultClient(log, r.flinkClientTimeout),
 		request:       request,
 		eventRecorder: r.EventRecorder,
 		observed:      ObservedClusterState{},

--- a/controllers/flinkcluster/suite_test.go
+++ b/controllers/flinkcluster/suite_test.go
@@ -79,7 +79,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	reconciler, err := NewReconciler(k8sManager)
+	reconciler, err := NewReconciler(k8sManager, 30*time.Second)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = reconciler.SetupWithManager(k8sManager, 1)

--- a/helm-chart/flink-operator/templates/flink-operator.yaml
+++ b/helm-chart/flink-operator/templates/flink-operator.yaml
@@ -69,6 +69,7 @@ spec:
             - --enable-leader-election
             - --zap-devel=false
             - --watch-namespace={{ .Values.watchNamespace.name }}
+            - --flink-client-timeout={{ .Values.flinkClientTimeout }}
           command:
             - /flink-operator
           image: {{ .Values.operatorImage.name }}

--- a/helm-chart/flink-operator/update_template.sh
+++ b/helm-chart/flink-operator/update_template.sh
@@ -18,6 +18,7 @@ function modifyManifests() {
   yqi "$rbacProxySelector |= sort_keys(.)"
 
   yqi "$managerSelector"'.args += "--watch-namespace=__WATCH_NAMESPACE__"'
+  yqi "$managerSelector"'.args += "--flink-client-timeout=__FLINK_CLIENT_TIMEOUT__"'
   yqi "$managerSelector"'.resources.limits.cpu = "__LIMITS_CPU__"'
   yqi "$managerSelector"'.resources.limits.memory = "__LIMITS_MEMORY__"'
   yqi "$managerSelector"'.resources.requests.cpu = "__REQUESTS_CPU__"'
@@ -37,6 +38,7 @@ function modifyManifests() {
 
 function helmTemplating() {
   sed 's/__WATCH_NAMESPACE__/{{ .Values.watchNamespace.name }}/' |
+  sed 's/__FLINK_CLIENT_TIMEOUT__/{{ .Values.flinkClientTimeout }}/' |
   sed 's/__SERVICE_ACCOUNT__/{{ template "flink-operator.serviceAccountName" . }}/' |
   sed 's/__NAMESPACE__/{{ .Values.flinkOperatorNamespace.name }}/g' |
   sed 's/__LIMITS_CPU__/{{ .Values.resources.limits.cpu }}/' |

--- a/helm-chart/flink-operator/values.yaml
+++ b/helm-chart/flink-operator/values.yaml
@@ -6,6 +6,9 @@ flinkOperatorNamespace:
 watchNamespace:
   name: ""
 
+# Timeout for Flink REST API requests
+flinkClientTimeout: 30s
+
 # The number of replicas of the operator Deployment
 replicas: 1
 

--- a/internal/flink/client.go
+++ b/internal/flink/client.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 )
@@ -322,8 +323,8 @@ func (c *Client) GetJobExceptions(apiBaseURL string, jobId string) (*JobExceptio
 	return exp, nil
 }
 
-func NewDefaultClient(log logr.Logger) *Client {
-	return NewClient(log, &http.Client{})
+func NewDefaultClient(log logr.Logger, timeout time.Duration) *Client {
+	return NewClient(log, &http.Client{Timeout: timeout})
 }
 
 func NewClient(log logr.Logger, httpClient *http.Client) *Client {

--- a/main.go
+++ b/main.go
@@ -19,7 +19,9 @@ package main
 import (
 	"crypto/tls"
 	"flag"
+	"fmt"
 	"os"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
@@ -52,7 +54,15 @@ var (
 	leaderElectionID        = flag.String("leader-election-id", "flink-operator-lock", "The name that leader election will use for holding the leader lock")
 	watchNamespace          = flag.String("watch-namespace", "", "Watch custom resources in the namespace, ignore other namespaces. If empty, all namespaces will be watched.")
 	maxConcurrentReconciles = flag.Int("max-concurrent-reconciles", 1, "The maximum number of concurrent Reconciles which can be run. Defaults to 1.")
+	flinkClientTimeout      = flag.Duration("flink-client-timeout", 30*time.Second, "The timeout for Flink REST API requests.")
 )
+
+func validateFlinkClientTimeout(timeout time.Duration) error {
+	if timeout <= 0 {
+		return fmt.Errorf("flink-client-timeout must be greater than zero")
+	}
+	return nil
+}
 
 func init() {
 	appsv1.AddToScheme(scheme)
@@ -74,6 +84,10 @@ func main() {
 		WithName("controllers").
 		WithName("FlinkCluster")
 	ctrl.SetLogger(logger)
+	if err := validateFlinkClientTimeout(*flinkClientTimeout); err != nil {
+		setupLog.Error(err, "Invalid configuration")
+		os.Exit(1)
+	}
 
 	defaultNamespaces := make(map[string]cache.Config)
 	if *watchNamespace != "" {
@@ -108,7 +122,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	reconciler, err := flinkcluster.NewReconciler(mgr)
+	reconciler, err := flinkcluster.NewReconciler(mgr, *flinkClientTimeout)
 	if err != nil {
 		setupLog.Error(err, "Unable to create reconciler")
 		os.Exit(1)


### PR DESCRIPTION
## Summary

Flink REST requests can block reconciliation when the JobManager endpoint is unreachable or unresponsive. The default timeout is not configured explicitly - a default 30s is used. 

```json
{
  "ts": "2026-09-11T07:53:50Z",
  "msg": "Failed to get Flink job status list.",
  "controller": "flinkcluster",
  "controllerGroup": "flinkoperator.k8s.io",
  "controllerKind": "FlinkCluster",
  "FlinkCluster": {"name": "event-counter", "namespace": "examples-streaming-java-production"},
  "namespace": "examples-streaming-java-production",
  "name": "event-counter",
  "reconcileID": "8b7319d4-c33b-44f9-ab3e-47bd5bd1e199",
  "error": "Get \"http://event-counter-jobmanager.examples-streaming-java-production.svc.cluster.local:8081/jobs/overview\": dial tcp 10.160.149.208:8081: i/o timeout"
}
```

This change introduces the operator-wide `--flink-client-timeout` option. The timeout defaults to 30s, preserving the existing connection-timeout behavior, while also bounding response processing. The Helm chart exposes the setting as `flinkClientTimeout`. Zero and negative values are rejected during operator startup.