### PR TITLE
Adapt update-savepoint status polling frequency

### DIFF
--- a/controllers/flinkcluster/flinkcluster_reconciler.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler.go
@@ -631,12 +631,19 @@ func (reconciler *ClusterReconciler) reconcileJob(ctx context.Context) (ctrl.Res
 			log.Info("Preparing job update")
 			var takeSavepoint = jobSpec.TakeSavepointOnUpdate == nil || *jobSpec.TakeSavepointOnUpdate
 			var shouldSuspend = takeSavepoint && util.IsBlank(jobSpec.FromSavepoint)
+			var savepointStatus = recorded.Savepoint
 			if shouldSuspend {
 				newSavepointStatus, err = reconciler.trySuspendJob(ctx)
+				if newSavepointStatus != nil {
+					savepointStatus = newSavepointStatus
+				}
 			} else if shouldUpdateJob(&observed) {
 				err = reconciler.cancelJob(ctx)
 			}
-			return requeueResult, err
+			return ctrl.Result{
+				Requeue:      true,
+				RequeueAfter: getUpdateSavepointRequeueInterval(savepointStatus, time.Now()),
+			}, err
 		}
 
 		// Trigger savepoint if required.
@@ -1198,4 +1205,31 @@ func getTimeAfterAddedSeconds(rawTime string, addedSeconds int64) time.Time {
 		lastTriggerTime = tc.FromString(rawTime)
 	}
 	return lastTriggerTime.Add(time.Duration(addedSeconds * int64(time.Second)))
+}
+
+func getUpdateSavepointRequeueInterval(savepoint *v1beta1.SavepointStatus, now time.Time) time.Duration {
+	if isUpdateSavepointInProgress(savepoint) {
+		triggerTime, err := time.Parse(time.RFC3339, savepoint.TriggerTime)
+		if err == nil && !triggerTime.After(now) {
+			triggerAge := now.Sub(triggerTime)
+			switch {
+			case triggerAge <= 4*time.Second:
+				return time.Second
+			case triggerAge <= 10*time.Second:
+				return 2 * time.Second
+			case triggerAge <= 30*time.Second:
+				return 5 * time.Second
+			default:
+				return 10 * time.Second
+			}
+		}
+	}
+
+	return JobCheckInterval
+}
+
+func isUpdateSavepointInProgress(savepoint *v1beta1.SavepointStatus) bool {
+	return savepoint != nil &&
+		savepoint.TriggerReason == v1beta1.SavepointReasonUpdate &&
+		savepoint.State == v1beta1.SavepointStateInProgress
 }

--- a/controllers/flinkcluster/flinkcluster_reconciler_test.go
+++ b/controllers/flinkcluster/flinkcluster_reconciler_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	v1beta1 "github.com/spotify/flink-on-k8s-operator/apis/flinkcluster/v1beta1"
@@ -838,6 +839,51 @@ func TestCancelFlinkJob_StopWithSavepoint_Timeout(t *testing.T) {
 	if sp.State != v1beta1.SavepointStateFailed {
 		t.Errorf("expected savepoint state %q, got %q", v1beta1.SavepointStateFailed, sp.State)
 	}
+}
+
+func TestGetUpdateSavepointRequeueInterval(t *testing.T) {
+	now := time.Date(2026, time.September, 9, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name             string
+		savepointAge     time.Duration
+		expectedInterval time.Duration
+	}{
+		{name: "savepoint up to four seconds old", savepointAge: 4 * time.Second, expectedInterval: time.Second},
+		{name: "savepoint up to ten seconds old", savepointAge: 10 * time.Second, expectedInterval: 2 * time.Second},
+		{name: "savepoint up to thirty seconds old", savepointAge: 30 * time.Second, expectedInterval: 5 * time.Second},
+		{name: "older savepoint", savepointAge: 31 * time.Second, expectedInterval: 10 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// given: an update savepoint in progress
+			savepoint := &v1beta1.SavepointStatus{
+				TriggerReason: v1beta1.SavepointReasonUpdate,
+				State:         v1beta1.SavepointStateInProgress,
+				TriggerTime:   now.Add(-tt.savepointAge).Format(time.RFC3339),
+			}
+
+			// when: the next reconcile is scheduled
+			interval := getUpdateSavepointRequeueInterval(savepoint, now)
+
+			// then: the interval reflects the savepoint age
+			assert.Equal(t, interval, tt.expectedInterval)
+		})
+	}
+}
+
+func TestGetUpdateSavepointRequeueIntervalUsesDefault(t *testing.T) {
+	// given: an update savepoint is no longer in progress
+	savepoint := &v1beta1.SavepointStatus{
+		TriggerReason: v1beta1.SavepointReasonUpdate,
+		State:         v1beta1.SavepointStateSucceeded,
+	}
+
+	// when: the next reconcile is scheduled
+	interval := getUpdateSavepointRequeueInterval(savepoint, time.Now())
+
+	// then: the normal job check interval is used
+	assert.Equal(t, interval, JobCheckInterval)
 }
 
 // --- Test helpers ---


### PR DESCRIPTION
## Summary

Update savepoints were checked using the fixed 10-second job interval, unnecessarily delaying restarts when savepoints completed quickly.

This change adjusts the polling interval based on savepoint age:

- 1s for the first 4 seconds
- 2s until 10 seconds
- 5s until 30 seconds
- 10s thereafter

Other savepoint states retain the existing job-check interval.